### PR TITLE
Save SVG <g> id attribute in SVG interpreter.

### DIFF
--- a/src/two.js
+++ b/src/two.js
@@ -338,6 +338,8 @@
             case 'stroke':
               elem.stroke = v.nodeValue;
               break;
+            case 'id':
+              elem._svgId = v.nodeValue;
           }
 
         });


### PR DESCRIPTION
Adding case statement for applySvgAttributes to save original SVG group IDs into Two.Group._svgId
