### PR TITLE
Adding case statement to applySvgAttributes to save original group id. 

### DIFF
--- a/src/two.js
+++ b/src/two.js
@@ -340,6 +340,7 @@
               break;
             case 'id':
               elem._svgId = v.nodeValue;
+              break;
           }
 
         });


### PR DESCRIPTION
stores <g id="myId"></g> to Two.Group._svgId = "myId"
