### PR TITLE
Use underscore instead of hyphens in ids

### DIFF
--- a/src/two.js
+++ b/src/two.js
@@ -139,7 +139,7 @@
 
     Version: 'v0.4.0',
 
-    Identifier: 'two-',
+    Identifier: 'two_',
 
     Properties: {
       hierarchy: 'hierarchy',


### PR DESCRIPTION
So that you can access objects properties with the dot notation 
(Two.scene.children.two-2 wouldn't work, Two.scene.children.two_2 does work)

Helpful when debugging.
