### PR TITLE
Add opacity support for groups

### DIFF
--- a/src/renderer/svg.js
+++ b/src/renderer/svg.js
@@ -211,6 +211,11 @@
           svg.group.renderChild.call(domElement, this.children[id]);
         }
 
+        // FIXME: Is this the best way to do this?
+        if (!_.isUndefined(this.opacity)) {
+          this._renderer.elem.setAttribute('opacity', this.opacity );
+        }
+
         if (this._flagAdditions) {
           _.each(this.additions, svg.group.appendChild, context);
         }


### PR DESCRIPTION
I want to add support for adding opacity support for groups. This patch works, but I'm not sure if it the right way.Could you advise?

Regarding my project: It's a Uni project about the book "Invisible Cities" by Italo Calvino. Each student is creating on "interactive illustration" for one of the described cities, and in the end they should be all running side by side on ipads. I'm using two.js to animate my cit(ies) which I drew in Illustrator. I'll send you a link once we're done.
