### PR TITLE
Use parentNode instead of parentElement in SVG renderer

### DIFF
--- a/src/renderer/svg.js
+++ b/src/renderer/svg.js
@@ -212,7 +212,7 @@
 
         var elem = object._renderer.elem;
 
-        if (!elem || elem.parentElement != this.elem) {
+        if (!elem || elem.parentNode != this.elem) {
           return;
         }
 


### PR DESCRIPTION
IE11 doesn't set parentElement on SVG elements, causing removal to fail with the SVG renderer. Using parentNode to find the element's parent instead allows object removals to occur correctly on update.