### PR TITLE
DomElement parameter overrides type parameter only if the element does not support default or set renderer type.

### DIFF
--- a/src/two.js
+++ b/src/two.js
@@ -76,9 +76,12 @@
       this[k] = v;
     }, this);
 
-    // Specified domElement overrides type declaration.
+    // Specified domElement overrides type declaration only if the element does not support declared renderer type.
     if (_.isElement(params.domElement)) {
-      this.type = Two.Types[params.domElement.tagName.toLowerCase()];
+      var tagName = params.domElement.tagName.toLowerCase();
+      if (!/^(CanvasRenderer-canvas|WebGLRenderer-canvas|SVGRenderer-svg)$/.test(this.type+'-'+tagName)) {
+        this.type = Two.Types[tagName];
+      }
     }
 
     this.renderer = new Two[this.type](this);


### PR DESCRIPTION
This PR makes it possible to declare the `WebGLRenderer` but at the same time have a `domElement` of type `canvas` without the library overriding the type to `CanvasRenderer`.