### PR TITLE
remove backbone from global space

### DIFF
--- a/third-party/events.js
+++ b/third-party/events.js
@@ -8,7 +8,6 @@
 
   var root = this;
   var Backbone = root.Backbone || {};
-  root.Backbone = Backbone;
 
   var array = [];
   var slice = array.slice;


### PR DESCRIPTION
Backbone is added to the global space before the AMD and CommonJS checks, leaving window.Backbone accessible when compiling with Browserify or Webpack.

5 tests are failing, but they're failing on master, too.