### PR TITLE
Vector.rotate, and fix for stopListening

### DIFF
--- a/src/two.js
+++ b/src/two.js
@@ -1757,6 +1757,7 @@ this.Two = (function(previousTwo) {
               if (callback) {
                 for (var j = 0, k = list.length; j < k; j++) {
                   var ev = list[j];
+                  ev = ev.callback ? ev.callback : ev;
                   if (callback && callback !== ev) {
                     events.push(ev);
                   }
@@ -1782,9 +1783,16 @@ this.Two = (function(previousTwo) {
           var bound = this;
 
           if (obj) {
-            obj.on(name, function () {
+            var ev = function () {
               callback.apply(bound, arguments);
-            });
+            };
+
+            // add references about the object that assigned this listener
+            ev.obj = obj;
+            ev.name = name;
+            ev.callback = callback;
+
+            obj.on(name, ev);
           }
 
           return this;

--- a/src/vector.js
+++ b/src/vector.js
@@ -144,8 +144,10 @@
     },
 
     rotate: function (radians) {
-      var newX = this.x * Math.cos(radians) - this.y * Math.sin(radians);
-      var newY = this.x * Math.sin(radians) + this.y * Math.cos(radians);
+      var cos = Math.cos(radians),
+          sin = Math.sin(radians),
+          newX = this.x * cos - this.y * sin,
+          newY = this.x * sin + this.y * cos;
       return this.set(newX, newY);
     }
 

--- a/src/vector.js
+++ b/src/vector.js
@@ -270,6 +270,13 @@
 
     toObject: function() {
       return { x: this._x, y: this._y };
+    },
+
+    rotate: function (radians) {
+      var newX = this.x * Math.cos(radians) - this.y * Math.sin(radians);
+      var newY = this.x * Math.sin(radians) + this.y * Math.cos(radians);
+      this.set(newX, newY);
+      return this;
     }
 
   };

--- a/src/vector.js
+++ b/src/vector.js
@@ -146,8 +146,7 @@
     rotate: function (radians) {
       var newX = this.x * Math.cos(radians) - this.y * Math.sin(radians);
       var newY = this.x * Math.sin(radians) + this.y * Math.cos(radians);
-      this.set(newX, newY);
-      return this;
+      return this.set(newX, newY);;
     }
 
   });

--- a/src/vector.js
+++ b/src/vector.js
@@ -146,7 +146,7 @@
     rotate: function (radians) {
       var newX = this.x * Math.cos(radians) - this.y * Math.sin(radians);
       var newY = this.x * Math.sin(radians) + this.y * Math.cos(radians);
-      return this.set(newX, newY);;
+      return this.set(newX, newY);
     }
 
   });

--- a/src/vector.js
+++ b/src/vector.js
@@ -141,6 +141,13 @@
 
     toObject: function() {
       return { x: this.x, y: this.y };
+    },
+
+    rotate: function (radians) {
+      var newX = this.x * Math.cos(radians) - this.y * Math.sin(radians);
+      var newY = this.x * Math.sin(radians) + this.y * Math.cos(radians);
+      this.set(newX, newY);
+      return this;
     }
 
   });
@@ -270,13 +277,6 @@
 
     toObject: function() {
       return { x: this._x, y: this._y };
-    },
-
-    rotate: function (radians) {
-      var newX = this.x * Math.cos(radians) - this.y * Math.sin(radians);
-      var newY = this.x * Math.sin(radians) + this.y * Math.cos(radians);
-      this.set(newX, newY);
-      return this;
     }
 
   };


### PR DESCRIPTION
I found a problem with my earlier implementation of listenTo. Since event handlers are wrapped in a function with a different scope, when calling .off() the specified callback won't match the callback in _events (since its wrapped in another function created by listenTo). There's probably a better way to fix this than the solution I have here, but for now it works!

Also, I added a helpful function for rotating individual vectors!