### PR TITLE
Changes gradientUnits default value to objectBoundingBox

### DIFF
--- a/src/renderer/svg.js
+++ b/src/renderer/svg.js
@@ -572,7 +572,7 @@
         if (!this._renderer.elem) {
 
           changed.id = this.id;
-          changed.gradientUnits = 'userSpaceOnUse';
+          changed.gradientUnits = 'objectBoundingBox';
           this._renderer.elem = svg.createElement('linearGradient', changed);
           domElement.defs.appendChild(this._renderer.elem);
 
@@ -652,7 +652,7 @@
         if (!this._renderer.elem) {
 
           changed.id = this.id;
-          changed.gradientUnits = 'userSpaceOnUse';
+          changed.gradientUnits = 'objectBoundingBox';
           this._renderer.elem = svg.createElement('radialGradient', changed);
           domElement.defs.appendChild(this._renderer.elem);
 


### PR DESCRIPTION
According to the [W3C recommendation](https://www.w3.org/TR/SVG/pservers.html#LinearGradientElementGradientUnitsAttribute) the default value of `gradientUnits` attribute is `objectBoundingBox` if not specified.

This PR changes SVG render to use `objectBoundingBox` as default value instead `userSpaceOnUse`.