### PR TITLE
Fix Grunt build task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,10 +100,10 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-qunit');
 
   // Default task
-  grunt.registerTask('default', ['jshint' , 'concat', 'uglify']);
+  grunt.registerTask('default', ['jshint' , 'concat', 'closureCompiler']);
 
   // Closure Compiler fallback
-  grunt.registerTask('build-uglify', ['jshint' , 'concat', 'closureCompiler']);
+  grunt.registerTask('build-uglify', ['jshint' , 'concat', 'uglify']);
 
   // Headless testing
   grunt.registerTask('test', ['connect', 'qunit']);


### PR DESCRIPTION
The task `build-uglify` is using the Closure Compiler instead Uglify and the `default` task is using Uglify instead the Closure Compiler.