### PR TITLE
Only render group children if group is visible

### DIFF
--- a/src/renderer/canvas.js
+++ b/src/renderer/canvas.js
@@ -64,9 +64,11 @@
           canvas[mask._renderer.type].render.call(mask, ctx, true);
         }
 
-        for (var i = 0; i < this.children.length; i++) {
-          var child = this.children[i];
-          canvas[child._renderer.type].render.call(child, ctx);
+        if (this.opacity > 0 && this.scale !== 0) {
+          for (var i = 0; i < this.children.length; i++) {
+            var child = this.children[i];
+            canvas[child._renderer.type].render.call(child, ctx);
+          }
         }
 
         if (!defaultMatrix) {


### PR DESCRIPTION
Basically, if a group is not visible (no opacity or scale 0), there's no need of rendering it's children.

I usually have all my entities in the scene and hide them when I don't need them. This way I can initialize them all at the beginning and don't need to add/remove them during the lifetime of the program. I think it's a common approach.

With this change, I have huge performance improvements (about 8x, but that's because I have tones of hidden entities).

Peace! Have a nice day ✨