### PR TITLE
Remove Node `canvas` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "url": "https://github.com/jonobr1/two.js/issues"
   },
   "license": "MIT",
-  "dependencies": {
-    "canvas": "^1.6.7"
-  },
   "devDependencies": {
     "animation-frame": "^0.1.7",
     "blueimp-canvas-to-blob": "^2.1.0",


### PR DESCRIPTION
The README now shows how to link Node `canvas` at runtime, so it isn't needed as a direct dependency in Two.js' package.json.