### PR TITLE
Enable ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+	"extends": "eslint:recommended",
+	"env": {
+		"browser": true,
+		"commonjs": true,
+		"amd": true
+	},
+	"globals": {
+		"global": "writable"
+	},
+	"rules": {
+		"semi": ["error", "always"],
+		"no-unused-vars": "off"
+	},
+	"overrides": [
+		{
+			"files": ["utils/**"],
+			"env": {
+				"node": true
+			}
+		},
+		{
+			"files": ["tests/**"],
+			"globals": {
+				"QUnit": "writable",
+				"resemble": "writable",
+				"Two": "writable",
+				"_": "writable"
+			},
+			"rules": {
+				"no-redeclare": "off"
+			}
+		}
+	],
+	"ignorePatterns": ["build/", "utils/start-comment.js", "utils/end-comment.js", "utils/exports.js"]
+}

--- a/extras/zui.js
+++ b/extras/zui.js
@@ -106,7 +106,7 @@
 
     addLimits: function(min, max, type) {
 
-      var type = type || 'scale';
+      type = type || 'scale';
 
       if (!_.isUndefined(min)) {
         if (this.limits[type].min) {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "extras",
     "src"
   ],
+  "scripts": {
+    "lint": "eslint ."
+  },
   "directories": {
     "doc": "documentation",
     "test": "tests",
@@ -50,6 +53,7 @@
   "devDependencies": {
     "animation-frame": "^0.1.7",
     "blueimp-canvas-to-blob": "^2.1.0",
+    "eslint": "^6.7.2",
     "jsdoc": "~3.5.5",
     "jsdoc-to-markdown": "^4.0.1",
     "moment": "^2.22.2",

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -35,7 +35,7 @@
 
     // Append the `controls` object only if control points are specified,
     // keeping the Two.Anchor inline with a Two.Vector until it needs to
-    // evolve beyond those functions — e.g: a simple 2 component vector.
+    // evolve beyond those functions - e.g: a simple 2 component vector.
     if (ilx || ily || irx || iry) {
       Two.Anchor.AppendCurveProperties(this);
     }

--- a/src/effects/image-sequence.js
+++ b/src/effects/image-sequence.js
@@ -368,7 +368,7 @@
     clone: function(parent) {
 
       var clone = new ImageSequence(this.textures, this.translation.x,
-        this.translation.y, this.frameRate)
+        this.translation.y, this.frameRate);
 
       clone._loop = this._loop;
 

--- a/src/effects/sprite.js
+++ b/src/effects/sprite.js
@@ -100,7 +100,7 @@
 
     }
 
-  })
+  });
 
   _.extend(Sprite.prototype, Rectangle.prototype, {
 

--- a/src/effects/texture.js
+++ b/src/effects/texture.js
@@ -265,7 +265,6 @@
 
         if (Two.Utils.isHeadless) {
           throw new Two.Utils.Error('video textures are not implemented in headless environments.');
-          return;
         }
 
         texture.image.setAttribute('two-src', texture.src);
@@ -529,7 +528,7 @@
         repeat: this.repeat,
         origin: this.origin.toObject(),
         scale: _.isNumber(this.scale) ? this.scale : this.scale.toObject()
-      }
+      };
     },
 
     /**

--- a/src/group.js
+++ b/src/group.js
@@ -703,7 +703,7 @@
       for (var i = 0; i < objects.length; i++) {
         var child = objects[i];
         if (!(child && child.id)) {
-          continue
+          continue;
         }
         var index = _.indexOf(this.children, child);
         if (index >= 0) {

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -474,7 +474,7 @@
      var e = fix(elements[4]);
      var f = fix(elements[5]);
 
-      if (!!fullMatrix) {
+      if (fullMatrix) {
 
         var g = fix(elements[6]);
         var h = fix(elements[7]);
@@ -533,7 +533,7 @@
      var e = elements[4];
      var f = elements[5];
 
-      if (!!fullMatrix) {
+      if (fullMatrix) {
 
         var g = elements[6];
         var h = elements[7];

--- a/src/path.js
+++ b/src/path.js
@@ -832,13 +832,13 @@
       // TODO: Update this to not __always__ update. Just when it needs to.
       this._update(true);
 
-      matrix = !!shallow ? this._matrix : getComputedMatrix(this);
+      matrix = shallow ? this._matrix : getComputedMatrix(this);
 
       border = this.linewidth / 2;
       l = this._renderer.vertices.length;
 
       if (l <= 0) {
-        v = matrix.multiply(0, 0, 1);
+        var v = matrix.multiply(0, 0, 1);
         return {
           top: v.y,
           left: v.x,

--- a/src/renderer/canvas.js
+++ b/src/renderer/canvas.js
@@ -312,7 +312,7 @@
 
         if (!clip && !parentClipped) {
           if (!canvas.isHidden.test(fill)) {
-            isOffset = fill._renderer && fill._renderer.offset
+            isOffset = fill._renderer && fill._renderer.offset;
             if (isOffset) {
               ctx.save();
               ctx.translate(

--- a/src/renderer/webgl.js
+++ b/src/renderer/webgl.js
@@ -128,13 +128,14 @@
         this._renderer.opacity = this._opacity
           * (parent && parent._renderer ? parent._renderer.opacity : 1);
 
+        var i;
         if (this._flagSubtractions) {
-          for (var i = 0; i < this.subtractions.length; i++) {
+          for (i = 0; i < this.subtractions.length; i++) {
             webgl.group.removeChild(this.subtractions[i], gl);
           }
         }
 
-        for (var i = 0; i < this.children.length; i++) {
+        for (i = 0; i < this.children.length; i++) {
           var child = this.children[i];
           webgl[child._renderer.type].render.call(child, gl, program);
         }
@@ -257,7 +258,7 @@
               var largeArcFlag = b.largeArcFlag;
               var sweepFlag = b.sweepFlag;
 
-              prev = closed ? mod(i - 1, length) : max(i - 1, 0);
+              prev = closed ? mod(i - 1, length) : Math.max(i - 1, 0);
               a = commands[prev];
 
               var ax = toFixed(a.x);
@@ -346,7 +347,7 @@
         }
 
         if (!webgl.isHidden.test(fill)) {
-          isOffset = fill._renderer && fill._renderer.offset
+          isOffset = fill._renderer && fill._renderer.offset;
           if (isOffset) {
             ctx.save();
             ctx.translate(
@@ -1202,7 +1203,7 @@
    */
   var Renderer = Two[Two.Types.webgl] = function(params) {
 
-    var params, gl, vs, fs;
+    var gl, vs, fs;
 
     /**
      * @name Two.WebGLRenderer#domElement

--- a/src/shapes/arc-segment.js
+++ b/src/shapes/arc-segment.js
@@ -56,7 +56,7 @@
       this.translation.y = oy;
     }
 
-  }
+  };
 
   _.extend(ArcSegment, {
 
@@ -353,7 +353,7 @@
       var object = Path.prototype.toObject.call(this);
 
       _.each(ArcSegment.Properties, function(property) {
-        object[property] = this[property]
+        object[property] = this[property];
       }, this);
 
       return object;

--- a/src/shapes/circle.js
+++ b/src/shapes/circle.js
@@ -186,7 +186,7 @@
       var object = Path.prototype.toObject.call(this);
 
       _.each(Circle.Properties, function(property) {
-        object[property] = this[property]
+        object[property] = this[property];
       }, this);
 
       return object;

--- a/src/shapes/ellipse.js
+++ b/src/shapes/ellipse.js
@@ -127,8 +127,8 @@
           var lx = i === 0 ? 0 : rx * c * cos(theta - HALF_PI);
           var ly = i === 0 ? 0 : ry * c * sin(theta - HALF_PI);
 
-          var rx = i === last ? 0 : rx * c * cos(theta + HALF_PI);
-          var ry = i === last ? 0 : ry * c * sin(theta + HALF_PI);
+          rx = i === last ? 0 : rx * c * cos(theta + HALF_PI);
+          ry = i === last ? 0 : ry * c * sin(theta + HALF_PI);
 
           var v = this.vertices[i];
 
@@ -205,7 +205,7 @@
       var object = Path.prototype.toObject.call(this);
 
       _.each(Ellipse.Properties, function(property) {
-        object[property] = this[property]
+        object[property] = this[property];
       }, this);
 
       return object;

--- a/src/shapes/polygon.js
+++ b/src/shapes/polygon.js
@@ -210,7 +210,7 @@
       var object = Path.prototype.toObject.call(this);
 
       _.each(Polygon.Properties, function(property) {
-        object[property] = this[property]
+        object[property] = this[property];
       }, this);
 
       return object;

--- a/src/shapes/rounded-rectangle.js
+++ b/src/shapes/rounded-rectangle.js
@@ -317,7 +317,7 @@
       var object = Path.prototype.toObject.call(this);
 
       _.each(RoundedRectangle.Properties, function(property) {
-        object[property] = this[property]
+        object[property] = this[property];
       }, this);
 
       object.radius = _.isNumber(this.radius)

--- a/src/shapes/star.js
+++ b/src/shapes/star.js
@@ -225,7 +225,7 @@
       var object = Path.prototype.toObject.call(this);
 
       _.each(Star.Properties, function(property) {
-        object[property] = this[property]
+        object[property] = this[property];
       }, this);
 
       return object;

--- a/src/text.js
+++ b/src/text.js
@@ -529,7 +529,7 @@
       // TODO: Update this to not __always__ update. Just when it needs to.
       this._update(true);
 
-      matrix = !!shallow ? this._matrix : getComputedMatrix(this);
+      matrix = shallow ? this._matrix : getComputedMatrix(this);
 
       var height = this.leading;
       var width = this.value.length * this.size * Text.Ratio;
@@ -614,7 +614,7 @@
       console.warn('Two.js: Unable to create canvas for Two.Text measurements.');
       return {
         getContext: _.identity
-      }
+      };
     }
   }
 

--- a/src/two.js
+++ b/src/two.js
@@ -6,7 +6,7 @@
   } else if (typeof global !== 'undefined') {
     root = global;
   } else if (typeof self !== 'undefined') {
-    root = self
+    root = self;
   } else {
     root = this;
   }
@@ -112,7 +112,7 @@
       return range;
     },
     indexOf: function(list, item) {
-      if (!!_.natural.indexOf) {
+      if (_.natural.indexOf) {
         return _.natural.indexOf.call(list, item);
       }
       for (var i = 0; i < list.length; i++) {
@@ -205,19 +205,19 @@
     once: function(func) {
       var init = false;
       return function() {
-        if (!!init) {
+        if (init) {
           return func;
         }
         init = true;
         return func.apply(this, arguments);
-      }
+      };
     },
     after: function(times, func) {
       return function() {
         while (--times < 1) {
           return func.apply(this, arguments);
         }
-      }
+      };
     },
     uniqueId: function(prefix) {
       var id = ++_._indexAmount + '';
@@ -1051,10 +1051,10 @@
               if (elem instanceof Two.Group) {
                 key = '_' + key;
               }
-              if (/url\(\#.*\)/i.test(value)) {
+              if (/url\(#.*\)/i.test(value)) {
                 var scene = Two.Utils.getScene(this);
                 elem[key] = scene.getById(
-                  value.replace(/url\(\#(.*)\)/i, '$1'));
+                  value.replace(/url\(#(.*)\)/i, '$1'));
               } else {
                 elem[key] = (/none/i.test(value)) ? 'transparent' : value;
               }
@@ -1137,7 +1137,7 @@
             var tag = n.nodeName;
             if (!tag) return;
 
-            var tagName = tag.replace(/svg\:/ig, '').toLowerCase();
+            var tagName = tag.replace(/svg:/ig, '').toLowerCase();
 
             if (tagName in Two.Utils.read) {
               var o = Two.Utils.read[tagName].call(group, n, styles);
@@ -1156,7 +1156,7 @@
           var points = node.getAttribute('points');
 
           var verts = [];
-          points.replace(/(-?[\d\.?]+)[,|\s](-?[\d\.?]+)/g, function(match, p1, p2) {
+          points.replace(/(-?[\d.?]+)[,|\s](-?[\d.?]+)/g, function(match, p1, p2) {
             verts.push(new Two.Anchor(parseFloat(p1), parseFloat(p2)));
           });
 
@@ -1196,7 +1196,7 @@
 
             var type = command[0];
             var lower = type.toLowerCase();
-            var items = command.slice(1).trim().split(/[\s,]+|(?=\s?[+\-])/);
+            var items = command.slice(1).trim().split(/[\s,]+|(?=\s?[+-])/);
             var pre, post, result = [], bin;
             var hasDoubleDecimals = false;
 
@@ -1309,10 +1309,10 @@
             var lower = type.toLowerCase();
 
             coords = command.slice(1).trim();
-            coords = coords.replace(/(-?\d+(?:\.\d*)?)[eE]([+\-]?\d+)/g, function(match, n1, n2) {
+            coords = coords.replace(/(-?\d+(?:\.\d*)?)[eE]([+-]?\d+)/g, function(match, n1, n2) {
               return parseFloat(n1) * pow(10, n2);
             });
-            coords = coords.split(/[\s,]+|(?=\s?[+\-])/);
+            coords = coords.split(/[\s,]+|(?=\s?[+-])/);
             relative = type === lower;
 
             var x1, y1, x2, y2, x3, y3, x4, y4, reflection;
@@ -1332,8 +1332,8 @@
                     Two.Commands.close
                   );
                   // Make coord be the last `m` command
-                  for (var i = points.length - 1; i >= 0; i--) {
-                    var point = points[i];
+                  for (var j = points.length - 1; j >= 0; j--) {
+                    var point = points[j];
                     if (/m/i.test(point.command)) {
                       coord = point;
                       break;
@@ -1562,7 +1562,7 @@
             return;
           }
 
-          var path = new Two.Path(points, closed, undefined, true).noStroke();
+          path = new Two.Path(points, closed, undefined, true).noStroke();
           path.fill = 'black';
 
           var rect = path.getBoundingClientRect(true);
@@ -1699,8 +1699,8 @@
             var child = node.children[i];
 
             var offset = child.getAttribute('offset');
-            if (/\%/ig.test(offset)) {
-              offset = parseFloat(offset.replace(/\%/ig, '')) / 100;
+            if (/%/ig.test(offset)) {
+              offset = parseFloat(offset.replace(/%/ig, '')) / 100;
             }
             offset = parseFloat(offset);
 
@@ -1708,13 +1708,14 @@
             var opacity = child.getAttribute('stop-opacity');
             var style = child.getAttribute('style');
 
+            var matches;
             if (_.isNull(color)) {
-              var matches = style ? style.match(/stop\-color\:\s?([\#a-fA-F0-9]*)/) : false;
+              matches = style ? style.match(/stop-color:\s?([#a-fA-F0-9]*)/) : false;
               color = matches && matches.length > 1 ? matches[1] : undefined;
             }
 
             if (_.isNull(opacity)) {
-              var matches = style ? style.match(/stop\-opacity\:\s?([0-9\.\-]*)/) : false;
+              matches = style ? style.match(/stop-opacity:\s?([0-9.-]*)/) : false;
               opacity = matches && matches.length > 1 ? parseFloat(matches[1]) : 1;
             } else {
               opacity = parseFloat(opacity);
@@ -1759,8 +1760,8 @@
             var child = node.children[i];
 
             var offset = child.getAttribute('offset');
-            if (/\%/ig.test(offset)) {
-              offset = parseFloat(offset.replace(/\%/ig, '')) / 100;
+            if (/%/ig.test(offset)) {
+              offset = parseFloat(offset.replace(/%/ig, '')) / 100;
             }
             offset = parseFloat(offset);
 
@@ -1768,13 +1769,14 @@
             var opacity = child.getAttribute('stop-opacity');
             var style = child.getAttribute('style');
 
+            var matches;
             if (_.isNull(color)) {
-              var matches = style ? style.match(/stop\-color\:\s?([\#a-fA-F0-9]*)/) : false;
+              matches = style ? style.match(/stop-color:\s?([#a-fA-F0-9]*)/) : false;
               color = matches && matches.length > 1 ? matches[1] : undefined;
             }
 
             if (_.isNull(opacity)) {
-              var matches = style ? style.match(/stop\-opacity\:\s?([0-9\.\-]*)/) : false;
+              matches = style ? style.match(/stop-opacity:\s?([0-9.-]*)/) : false;
               opacity = matches && matches.length > 1 ? parseFloat(matches[1]) : 1;
             } else {
               opacity = parseFloat(opacity);
@@ -2122,16 +2124,12 @@
        */
       getAnchorsFromArcData: function(center, xAxisRotation, rx, ry, ts, td, ccw) {
 
-        var matrix = new Two.Matrix()
-          .translate(center.x, center.y)
-          .rotate(xAxisRotation);
-
         var l = Two.Resolution;
 
         return _.map(_.range(l), function(i) {
 
           var pct = (i + 1) / l;
-          if (!!ccw) {
+          if (ccw) {
             pct = 1 - pct;
           }
 
@@ -2269,10 +2267,10 @@
           var names = name ? [name] : _.keys(this._events);
           for (var i = 0, l = names.length; i < l; i++) {
 
-            var name = names[i];
+            name = names[i];
             var list = this._events[name];
 
-            if (!!list) {
+            if (list) {
               var events = [];
               if (handler) {
                 for (var j = 0, k = list.length; j < k; j++) {
@@ -2320,7 +2318,7 @@
             event.name = name;
             event.handler = handler;
 
-            obj.on(name, ev);
+            obj.on(name, event);
 
           }
 
@@ -2942,7 +2940,7 @@
     makeSprite: function(path, x, y, cols, rows, frameRate, autostart) {
 
       var sprite = new Two.Sprite(path, x, y, cols, rows, frameRate);
-      if (!!autostart) {
+      if (autostart) {
         sprite.play();
       }
       this.add(sprite);
@@ -2965,7 +2963,7 @@
     makeImageSequence: function(paths, x, y, frameRate, autostart) {
 
       var imageSequence = new Two.ImageSequence(paths, x, y, frameRate);
-      if (!!autostart) {
+      if (autostart) {
         imageSequence.play();
       }
       this.add(imageSequence);
@@ -3018,12 +3016,13 @@
      * @param {Boolean} shallow - Don't create a top-most group but append all content directly.
      * @param {Boolean} add – Automatically add the reconstructed SVG node to scene.
      * @returns {Two.Group}
-     * @description Interpret an SVG Node and add it to this instance's scene. The distinction should be made that this doesn't `import` svg's, it solely interprets them into something compatible for Two.js — this is slightly different than a direct transcription.
+     * @description Interpret an SVG Node and add it to this instance's scene. The distinction should be made that this doesn't `import` svg's, it solely interprets them into something compatible for Two.js - this is slightly different than a direct transcription.
      */
     interpret: function(svgNode, shallow, add) {
 
-      var tag = svgNode.tagName.toLowerCase(),
-          add = (typeof add !== 'undefined') ? add : true;
+      var tag = svgNode.tagName.toLowerCase();
+
+      add = (typeof add !== 'undefined') ? add : true;
 
       if (!(tag in Two.Utils.read)) {
         return null;
@@ -3031,7 +3030,7 @@
 
       var node = Two.Utils.read[tag].call(this, svgNode);
 
-      if (!!add) {
+      if (add) {
         this.add(shallow && node instanceof Two.Group ? node.children : node);
       }
 

--- a/tests/suite/canvas.js
+++ b/tests/suite/canvas.js
@@ -6,7 +6,7 @@
 
   QUnit.module('CanvasRenderer');
 
-  var getRatio = function(v) { return Math.round(Two.Utils.getRatio(v)) };
+  var getRatio = function(v) { return Math.round(Two.Utils.getRatio(v));};
   var deviceRatio = getRatio(document.createElement('canvas').getContext('2d'));
   var suffix = '@' + deviceRatio + 'x.png';
 
@@ -257,7 +257,7 @@
 
         sequence.index = 7;
         texture = sequence.textures[sequence.index];
-        id = texture.id
+        id = texture.id;
         texture._flagImage = true;
 
         texture.bind(Two.Events.load, function() {

--- a/tests/suite/core.js
+++ b/tests/suite/core.js
@@ -74,7 +74,7 @@ QUnit.test('Two.Utils', function(assert) {
     return this.attr;
   }, { attr: 'Two.js' })(), 'Two.js', 'Bound function properly.');
   assert.equal(JSON.stringify(Two.Utils.extend({ a: 'b' }, { a: 'a', b: 'c' })), '{"a":"a","b":"c"}', 'Object extends properties successfully.');
-  assert.equal(JSON.stringify(Two.Utils.defaults({ a: 'b' }, { a: 'a', b: 'c' })), '{"a":"b","b":"c"}', 'Object defaults properties successfully.')
+  assert.equal(JSON.stringify(Two.Utils.defaults({ a: 'b' }, { a: 'a', b: 'c' })), '{"a":"b","b":"c"}', 'Object defaults properties successfully.');
   assert.equal(JSON.stringify(Two.Utils.keys({ a: 0, b: 1, c: 2 })), '["a","b","c"]', 'Two.Utils.keys successfully retrieves keys.');
   assert.equal(JSON.stringify(Two.Utils.values({ a: 0, b: 1, c: 2 })), '[0,1,2]', 'Two.Utils.values successfully retrieves keys.');
 
@@ -225,7 +225,7 @@ QUnit.test('Two.Vector', function(assert) {
 
   vector.set(9, 3);
   vector.rotate(Math.PI / 2);
-  assert.equal(vector.equals({ x: - 2.9999999999999996, y: - 2.9999999999999996}), true, 'Two.Vector.rotate applies x, y properly.')
+  assert.equal(vector.equals({ x: - 2.9999999999999996, y: - 2.9999999999999996}), true, 'Two.Vector.rotate applies x, y properly.');
 
 });
 

--- a/tests/suite/shapes.js
+++ b/tests/suite/shapes.js
@@ -68,7 +68,7 @@ QUnit.test('Two.Ellipse', function(assert) {
   assert.expect(Two.Ellipse.Properties.length * 4 + 1);
 
   var rx = 50;
-  var ry = 75
+  var ry = 75;
   var properties = [rx * 2, ry * 2];
 
   var path = new Two.Ellipse(0, 0, rx, ry);

--- a/tests/suite/webgl.js
+++ b/tests/suite/webgl.js
@@ -6,7 +6,7 @@
 
   QUnit.module('WebGLRenderer');
 
-  var getRatio = function (v) { return Math.round(Two.Utils.getRatio(v)) };
+  var getRatio = function (v) { return Math.round(Two.Utils.getRatio(v));};
   var deviceRatio = getRatio(document.createElement('canvas').getContext('2d'));
   var suffix = '@' + deviceRatio + 'x.png';
 
@@ -257,7 +257,7 @@
 
         sequence.index = 7;
         texture = sequence.textures[sequence.index];
-        id = texture.id
+        id = texture.id;
         texture._flagImage = true;
 
         texture.bind(Two.Events.load, function() {

--- a/utils/document.js
+++ b/utils/document.js
@@ -36,8 +36,8 @@ var explanation = compiler.explainSync({
 
 explanation.slice(0).forEach(function(object) {
   var a = object.undocumented;
-  var b = /package\:undefined/i.test(object.longname);
-  var c = /Two\.Utils\.Events\.(bind|unbind)/i.test(object.memberof)
+  var b = /package:undefined/i.test(object.longname);
+  var c = /Two\.Utils\.Events\.(bind|unbind)/i.test(object.memberof);
   if (a || b || c) {
     explanation.splice(explanation.indexOf(object), 1);
   }


### PR DESCRIPTION
This PR enables ESLint and lints the codebase with it.

The linting rules used are the "recommended" settings for ESLint, with the following exceptions:
- Semicolons are required. By default, ESLint doesn't take a position on the explicit semicolons/automatic semicolon insertion debate, and since this codebase uses semicolons, ESLint should enforce that usage consistently.
- Unused variables are allowed, owing to the number at which they are currently present in the codebase.

The vast majority of fixes fall into the following categories:

- [Removing unnecessary regex escapes](https://eslint.org/docs/rules/no-useless-escape#top)
- [Removing unnecessary double negations](https://eslint.org/docs/rules/no-extra-boolean-cast#top)
- Making `var` scoping more explicit
- [Not redeclaring function arguments as `var`s](https://eslint.org/docs/rules/no-redeclare#top)
- Adding missing semicolons
- [Removing irregular whitespace](https://eslint.org/docs/rules/no-irregular-whitespace#rule-details)

There are a few changes that may affect code behavior:
- In path.js, a global variable leak has been fixed (the variable `v` was missing a `var` statement and hence leaking into global scope)
- In webgl.js, one use of the undefined `max` function (I confirmed with a debugger that it's not defined in that scope) was replaced with Math.max
- In two.js line 1335, a loop that changed the value of `i` given by 'forEach' now uses the `j` variable--not sure if that changes anything
- In getAnchorsFromArcData (two.js line 2125), the unused 'matrix' variable declaration has been removed
- In Two.Utils.Events.trigger (two.js line 2321), `ev` has been changed to `event`. `ev` was not defined.