### PR TITLE
Fix scaling of paths and text in WebGL renderer when their scale is a Two.Vector

### DIFF
--- a/src/renderer/webgl.js
+++ b/src/renderer/webgl.js
@@ -232,7 +232,12 @@
 
         var d;
         ctx.save();
-        ctx.scale(scale, scale);
+        if (scale instanceof Two.Vector) {
+          ctx.scale(scale.x, scale.y);
+        } else {
+          ctx.scale(scale, scale);
+        }
+
         ctx.translate(cx, cy);
 
         ctx.beginPath();
@@ -637,7 +642,11 @@
         }
 
         ctx.save();
-        ctx.scale(scale, scale);
+        if (scale instanceof Two.Vector) {
+          ctx.scale(scale.x, scale.y);
+        } else {
+          ctx.scale(scale, scale);
+        }
         ctx.translate(cx, cy);
 
         if (!webgl.isHidden.test(fill)) {


### PR DESCRIPTION
When a path or text object is scaled by a `Two.Vector`, the renderer's canvas should be scaled by that vector's x and y values. Previously the code would pass the vector itself to `ctx.scale`.

I'm not familiar enough yet with the codebase to know whether the objects' scale factors are now *guaranteed* to be `Two.Vector`s and hence know whether or not the `scale instanceof Two.Vector` check is necessary.