### PR TITLE
Remove toFixed calls from canvas + WebGL renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ process.exit();
 ## Change Log
 
 #### Nightly
++ Removed `Two.Utils.toFixed` calls on Canvas and WebGLRenderers [@adroitwhiz](https://github.com/adroitwhiz)
 + `Two.Shape.clone` clones `Two.Shape.matrix` when `Two.Shape.matrix.manual` is set to `true`
 + Improved `Two.Group.mask` rendering in `Two.WebGLREnderer`
 + Fixed `Two.WebGLRenderer.setSize` recursive loop error

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -451,11 +451,7 @@
       array.length = 0;
       this.toTransformArray(fullMatrix, array);
 
-      return array.map(
-        function(item) {
-          return Two.Utils.toFixed(item);
-        }
-      ).join(' ');
+      return array.map(Two.Utils.toFixed).join(' ');
 
     },
 

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -3,7 +3,7 @@
   // Constants
 
   var cos = Math.cos, sin = Math.sin, tan = Math.tan;
-  var _ = Two.Utils, fix = _.toFixed;
+  var _ = Two.Utils;
   var array = [];
 
   /**
@@ -451,7 +451,11 @@
       array.length = 0;
       this.toTransformArray(fullMatrix, array);
 
-      return array.join(' ');
+      return array.map(
+        function(item) {
+          return Two.Utils.toFixed(item);
+        }
+      ).join(' ');
 
     },
 
@@ -467,18 +471,18 @@
      var elements = this.elements;
      var hasOutput = !!output;
 
-     var a = fix(elements[0]);
-     var b = fix(elements[1]);
-     var c = fix(elements[2]);
-     var d = fix(elements[3]);
-     var e = fix(elements[4]);
-     var f = fix(elements[5]);
+     var a = elements[0];
+     var b = elements[1];
+     var c = elements[2];
+     var d = elements[3];
+     var e = elements[4];
+     var f = elements[5];
 
       if (!!fullMatrix) {
 
-        var g = fix(elements[6]);
-        var h = fix(elements[7]);
-        var i = fix(elements[8]);
+        var g = elements[6];
+        var h = elements[7];
+        var i = elements[8];
 
         if (hasOutput) {
           output[0] = a;

--- a/src/path.js
+++ b/src/path.js
@@ -1192,7 +1192,6 @@
         }
 
         this._lengths[i] = getCurveLength(a, b, limit);
-        this._lengths[i] = Two.Utils.toFixed(this._lengths[i]);
         sum += this._lengths[i];
 
         if (i >= last && closed) {
@@ -1200,7 +1199,6 @@
           b = this.vertices[(i + 1) % length];
 
           this._lengths[i + 1] = getCurveLength(a, b, limit);
-          this._lengths[i + 1] = Two.Utils.toFixed(this._lengths[i + 1]);
           sum += this._lengths[i + 1];
 
         }

--- a/src/renderer/canvas.js
+++ b/src/renderer/canvas.js
@@ -3,7 +3,7 @@
   /**
    * Constants
    */
-  var mod = Two.Utils.mod, toFixed = Two.Utils.toFixed;
+  var mod = Two.Utils.mod;
   var getRatio = Two.Utils.getRatio;
   var _ = Two.Utils;
   var emptyArray = [];
@@ -206,8 +206,8 @@
 
           b = commands[i];
 
-          x = toFixed(b.x);
-          y = toFixed(b.y);
+          x = b.x;
+          y = b.y;
 
           switch (b.command) {
 
@@ -226,8 +226,8 @@
               prev = closed ? mod(i - 1, length) : max(i - 1, 0);
               a = commands[prev];
 
-              var ax = toFixed(a.x);
-              var ay = toFixed(a.y);
+              var ax = a.x;
+              var ay = a.y;
 
               canvas.renderSvgArcCommand(ctx, ax, ay, rx, ry, largeArcFlag, sweepFlag, xAxisRotation, x, y);
               break;
@@ -243,19 +243,19 @@
               bl = (b.controls && b.controls.left) || Two.Vector.zero;
 
               if (a._relative) {
-                vx = (ar.x + toFixed(a.x));
-                vy = (ar.y + toFixed(a.y));
+                vx = (ar.x + a.x);
+                vy = (ar.y + a.y);
               } else {
-                vx = toFixed(ar.x);
-                vy = toFixed(ar.y);
+                vx = ar.x;
+                vy = ar.y;
               }
 
               if (b._relative) {
-                ux = (bl.x + toFixed(b.x));
-                uy = (bl.y + toFixed(b.y));
+                ux = (bl.x + b.x);
+                uy = (bl.y + b.y);
               } else {
-                ux = toFixed(bl.x);
-                uy = toFixed(bl.y);
+                ux = bl.x;
+                uy = bl.y;
               }
 
               ctx.bezierCurveTo(vx, vy, ux, uy, x, y);
@@ -268,23 +268,23 @@
                 cl = (c.controls && c.controls.left) || Two.Vector.zero;
 
                 if (b._relative) {
-                  vx = (br.x + toFixed(b.x));
-                  vy = (br.y + toFixed(b.y));
+                  vx = (br.x + b.x);
+                  vy = (br.y + b.y);
                 } else {
-                  vx = toFixed(br.x);
-                  vy = toFixed(br.y);
+                  vx = br.x;
+                  vy = br.y;
                 }
 
                 if (c._relative) {
-                  ux = (cl.x + toFixed(c.x));
-                  uy = (cl.y + toFixed(c.y));
+                  ux = (cl.x + c.x);
+                  uy = (cl.y + c.y);
                 } else {
-                  ux = toFixed(cl.x);
-                  uy = toFixed(cl.y);
+                  ux = cl.x;
+                  uy = cl.y;
                 }
 
-                x = toFixed(c.x);
-                y = toFixed(c.y);
+                x = c.x;
+                y = c.y;
 
                 ctx.bezierCurveTo(vx, vy, ux, uy, x, y);
 
@@ -443,23 +443,23 @@
 
             if (fill._renderer && fill._renderer.offset) {
 
-              sx = toFixed(fill._renderer.scale.x);
-              sy = toFixed(fill._renderer.scale.y);
+              sx = fill._renderer.scale.x;
+              sy = fill._renderer.scale.y;
 
               ctx.save();
-              ctx.translate( - toFixed(fill._renderer.offset.x),
-                - toFixed(fill._renderer.offset.y));
+              ctx.translate( - fill._renderer.offset.x,
+                - fill._renderer.offset.y);
               ctx.scale(sx, sy);
 
               a = this._size / fill._renderer.scale.y;
               b = this._leading / fill._renderer.scale.y;
-              ctx.font = [this._style, this._weight, toFixed(a) + 'px/',
-                toFixed(b) + 'px', this._family].join(' ');
+              ctx.font = [this._style, this._weight, a + 'px/',
+                b + 'px', this._family].join(' ');
 
               c = fill._renderer.offset.x / fill._renderer.scale.x;
               d = fill._renderer.offset.y / fill._renderer.scale.y;
 
-              ctx.fillText(this.value, toFixed(c), toFixed(d));
+              ctx.fillText(this.value, c, d);
               ctx.restore();
 
             } else {
@@ -472,25 +472,25 @@
 
             if (stroke._renderer && stroke._renderer.offset) {
 
-              sx = toFixed(stroke._renderer.scale.x);
-              sy = toFixed(stroke._renderer.scale.y);
+              sx = stroke._renderer.scale.x;
+              sy = stroke._renderer.scale.y;
 
               ctx.save();
-              ctx.translate(- toFixed(stroke._renderer.offset.x),
-                - toFixed(stroke._renderer.offset.y));
+              ctx.translate(- stroke._renderer.offset.x,
+                - stroke._renderer.offset.y);
               ctx.scale(sx, sy);
 
               a = this._size / stroke._renderer.scale.y;
               b = this._leading / stroke._renderer.scale.y;
-              ctx.font = [this._style, this._weight, toFixed(a) + 'px/',
-                toFixed(b) + 'px', this._family].join(' ');
+              ctx.font = [this._style, this._weight, a + 'px/',
+                b + 'px', this._family].join(' ');
 
               c = stroke._renderer.offset.x / stroke._renderer.scale.x;
               d = stroke._renderer.offset.y / stroke._renderer.scale.y;
               e = linewidth / stroke._renderer.scale.x;
 
-              ctx.lineWidth = toFixed(e);
-              ctx.strokeText(this.value, toFixed(c), toFixed(d));
+              ctx.lineWidth = e;
+              ctx.strokeText(this.value, c, d);
               ctx.restore();
 
             } else {

--- a/src/renderer/webgl.js
+++ b/src/renderer/webgl.js
@@ -11,7 +11,6 @@
     transformation = new Two.Array(9),
     getRatio = Two.Utils.getRatio,
     getComputedMatrix = Two.Utils.getComputedMatrix,
-    toFixed = Two.Utils.toFixed,
     CanvasUtils = Two[Two.Types.canvas].Utils,
     _ = Two.Utils;
 
@@ -240,8 +239,8 @@
 
           var b = commands[i];
 
-          x = toFixed(b.x);
-          y = toFixed(b.y);
+          x = b.x;
+          y = b.y;
 
           switch (b.command) {
 
@@ -260,8 +259,8 @@
               prev = closed ? mod(i - 1, length) : max(i - 1, 0);
               a = commands[prev];
 
-              var ax = toFixed(a.x);
-              var ay = toFixed(a.y);
+              var ax = a.x;
+              var ay = a.y;
 
               CanvasUtils.renderSvgArcCommand(ctx, ax, ay, rx, ry, largeArcFlag, sweepFlag, xAxisRotation, x, y);
               break;
@@ -277,19 +276,19 @@
               bl = (b.controls && b.controls.left) || Two.Vector.zero;
 
               if (a._relative) {
-                vx = toFixed((ar.x + a.x));
-                vy = toFixed((ar.y + a.y));
+                vx = ar.x + a.x;
+                vy = ar.y + a.y;
               } else {
-                vx = toFixed(ar.x);
-                vy = toFixed(ar.y);
+                vx = ar.x;
+                vy = ar.y;
               }
 
               if (b._relative) {
-                ux = toFixed((bl.x + b.x));
-                uy = toFixed((bl.y + b.y));
+                ux = bl.x + b.x;
+                uy = bl.y + b.y;
               } else {
-                ux = toFixed(bl.x);
-                uy = toFixed(bl.y);
+                ux = bl.x;
+                uy = bl.y;
               }
 
               ctx.bezierCurveTo(vx, vy, ux, uy, x, y);
@@ -302,23 +301,23 @@
                 cl = (c.controls && c.controls.left) || Two.Vector.zero;
 
                 if (b._relative) {
-                  vx = toFixed((br.x + b.x));
-                  vy = toFixed((br.y + b.y));
+                  vx = br.x + b.x;
+                  vy = br.y + b.y;
                 } else {
-                  vx = toFixed(br.x);
-                  vy = toFixed(br.y);
+                  vx = br.x;
+                  vy = br.y;
                 }
 
                 if (c._relative) {
-                  ux = toFixed((cl.x + c.x));
-                  uy = toFixed((cl.y + c.y));
+                  ux = cl.x + c.x;
+                  uy = cl.y + c.y;
                 } else {
-                  ux = toFixed(cl.x);
-                  uy = toFixed(cl.y);
+                  ux = cl.x;
+                  uy = cl.y;
                 }
 
-                x = toFixed(c.x);
-                y = toFixed(c.y);
+                x = c.x;
+                y = c.y;
 
                 ctx.bezierCurveTo(vx, vy, ux, uy, x, y);
 
@@ -644,23 +643,23 @@
 
           if (fill._renderer && fill._renderer.offset) {
 
-            sx = toFixed(fill._renderer.scale.x);
-            sy = toFixed(fill._renderer.scale.y);
+            sx = fill._renderer.scale.x;
+            sy = fill._renderer.scale.y;
 
             ctx.save();
-            ctx.translate( - toFixed(fill._renderer.offset.x),
-              - toFixed(fill._renderer.offset.y));
+            ctx.translate( - fill._renderer.offset.x,
+              - fill._renderer.offset.y);
             ctx.scale(sx, sy);
 
             a = elem._size / fill._renderer.scale.y;
             b = elem._leading / fill._renderer.scale.y;
-            ctx.font = [elem._style, elem._weight, toFixed(a) + 'px/',
-              toFixed(b) + 'px', elem._family].join(' ');
+            ctx.font = [elem._style, elem._weight, a + 'px/',
+              b + 'px', elem._family].join(' ');
 
             c = fill._renderer.offset.x / fill._renderer.scale.x;
             d = fill._renderer.offset.y / fill._renderer.scale.y;
 
-            ctx.fillText(elem.value, toFixed(c), toFixed(d));
+            ctx.fillText(elem.value, c, d);
             ctx.restore();
 
           } else {
@@ -673,25 +672,25 @@
 
           if (stroke._renderer && stroke._renderer.offset) {
 
-            sx = toFixed(stroke._renderer.scale.x);
-            sy = toFixed(stroke._renderer.scale.y);
+            sx = stroke._renderer.scale.x;
+            sy = stroke._renderer.scale.y;
 
             ctx.save();
-            ctx.translate(- toFixed(stroke._renderer.offset.x),
-              - toFixed(stroke._renderer.offset.y));
+            ctx.translate(- stroke._renderer.offset.x,
+              - stroke._renderer.offset.y);
             ctx.scale(sx, sy);
 
             a = elem._size / stroke._renderer.scale.y;
             b = elem._leading / stroke._renderer.scale.y;
-            ctx.font = [elem._style, elem._weight, toFixed(a) + 'px/',
-              toFixed(b) + 'px', elem._family].join(' ');
+            ctx.font = [elem._style, elem._weight, a + 'px/',
+              b + 'px', elem._family].join(' ');
 
             c = stroke._renderer.offset.x / stroke._renderer.scale.x;
             d = stroke._renderer.offset.y / stroke._renderer.scale.y;
             e = linewidth / stroke._renderer.scale.x;
 
-            ctx.lineWidth = toFixed(e);
-            ctx.strokeText(elem.value, toFixed(c), toFixed(d));
+            ctx.lineWidth = e;
+            ctx.strokeText(elem.value, c, d);
             ctx.restore();
 
           } else {


### PR DESCRIPTION
Resolves #414 

This should clean up the code a bit and possibly even speed it up.

Any rendering differences between canvas and SVG should be negligible, and will be overshadowed by the difference between how browsers render SVGs and canvas elements anyway.

In addition, I moved the matrix value rounding from `toTransformArray` to `toString`.