### PR TITLE
Remove gl.colorMask calls from WebGL masking logic

### DIFF
--- a/src/renderer/webgl.js
+++ b/src/renderer/webgl.js
@@ -110,14 +110,11 @@
           gl.clear(gl.STENCIL_BUFFER_BIT);
           gl.enable(gl.STENCIL_TEST);
 
-          gl.colorMask(false, false, false, true);
-          gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
-
           gl.stencilFunc(gl.ALWAYS, 1, 0);
+          gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
 
           webgl[this._mask._renderer.type].render.call(this._mask, gl, program, this);
 
-          gl.colorMask(true, true, true, true);
           gl.stencilFunc(gl.EQUAL, 1, 0xff);
           gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
 


### PR DESCRIPTION
This fixes masks turning transparent backgrounds black, as seen in [this test case](https://github.com/jonobr1/two.js/files/3928237/eyes.html.zip).

That test case isn't the same "eyes" example as is currently on the site--I modified it to use masking.