### PR TITLE
Refactor WebGL

### DIFF
--- a/src/renderer/webgl.js
+++ b/src/renderer/webgl.js
@@ -43,10 +43,6 @@
         delete child._renderer.texture;
       },
 
-      renderChild: function(child) {
-        webgl[child._renderer.type].render.call(child, this.gl, this.program);
-      },
-
       render: function(gl, program) {
 
         this._update();
@@ -120,10 +116,10 @@
           }
         }
 
-        this.children.forEach(webgl.group.renderChild, {
-          gl: gl,
-          program: program
-        });
+        for (var i = 0; i < this.children.length; i++) {
+          var child = this.children[i];
+          webgl[child._renderer.type].render.call(child, gl, program);
+        }
 
         if (this._mask) {
           gl.disable(gl.STENCIL_TEST);

--- a/src/renderer/webgl.js
+++ b/src/renderer/webgl.js
@@ -29,15 +29,6 @@
 
     matrix: new Two.Matrix(),
 
-    uv: new Two.Array([
-      0, 0,
-      1, 0,
-      0, 1,
-      0, 1,
-      1, 0,
-      1, 1
-    ]),
-
     group: {
 
       removeChild: function(child, gl) {
@@ -88,13 +79,8 @@
           }
 
           if (!(/renderer/i.test(parent._renderer.type))) {
-            if (parent._renderer.scale instanceof Two.Vector) {
-              this._renderer.scale.x *= parent._renderer.scale.x;
-              this._renderer.scale.y *= parent._renderer.scale.y;
-            } else {
-              this._renderer.scale.x *= parent._renderer.scale;
-              this._renderer.scale.y *= parent._renderer.scale;
-            }
+            this._renderer.scale.x *= parent._renderer.scale.x;
+            this._renderer.scale.y *= parent._renderer.scale.y;
           }
 
           if (flagParentMatrix) {
@@ -132,11 +118,6 @@
           for (var i = 0; i < this.subtractions.length; i++) {
             webgl.group.removeChild(this.subtractions[i], gl);
           }
-        }
-
-        for (var i = 0; i < this.children.length; i++) {
-          var child = this.children[i];
-          webgl[child._renderer.type].render.call(child, gl, program);
         }
 
         this.children.forEach(webgl.group.renderChild, {
@@ -179,13 +160,8 @@
         var length = commands.length;
         var last = length - 1;
 
-        if (scale instanceof Two.Vector) {
-          canvas.width = Math.max(Math.ceil(elem._renderer.rect.width * scale.x), 1);
-          canvas.height = Math.max(Math.ceil(elem._renderer.rect.height * scale.y), 1);
-        } else {
-          canvas.width = Math.max(Math.ceil(elem._renderer.rect.width * scale), 1);
-          canvas.height = Math.max(Math.ceil(elem._renderer.rect.height * scale), 1);
-        }
+        canvas.width = Math.max(Math.ceil(elem._renderer.rect.width * scale.x), 1);
+        canvas.height = Math.max(Math.ceil(elem._renderer.rect.height * scale.y), 1);
 
         var centroid = elem._renderer.rect.centroid;
         var cx = centroid.x;
@@ -232,7 +208,8 @@
 
         var d;
         ctx.save();
-        ctx.scale(scale, scale);
+        ctx.scale(scale.x, scale.y);
+
         ctx.translate(cx, cy);
 
         ctx.beginPath();
@@ -510,16 +487,10 @@
             this._renderer.rect = {};
           }
 
-          if (!this._renderer.triangles) {
-            this._renderer.triangles = new Two.Array(12);
-          }
-
           this._renderer.opacity = this._opacity * parent._renderer.opacity;
 
           webgl.path.getBoundingClientRect(this._renderer.vertices, this._linewidth, this._renderer.rect);
-          webgl.getTriangles(this._renderer.rect, this._renderer.triangles);
 
-          webgl.updateBuffer.call(webgl, gl, this, program);
           webgl.updateTexture.call(webgl, gl, this);
 
         } else {
@@ -544,21 +515,12 @@
         }
 
         // Draw Texture
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this._renderer.textureCoordsBuffer);
-
-        gl.vertexAttribPointer(program.textureCoords, 2, gl.FLOAT, false, 0, 0);
-
         gl.bindTexture(gl.TEXTURE_2D, this._renderer.texture);
 
         // Draw Rect
-
+        var rect = this._renderer.rect;
         gl.uniformMatrix3fv(program.matrix, false, this._renderer.matrix);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this._renderer.buffer);
-
-        gl.vertexAttribPointer(program.position, 2, gl.FLOAT, false, 0, 0);
-
+        gl.uniform4f(program.rect, rect.left, rect.top, rect.right, rect.bottom);
         gl.drawArrays(gl.TRIANGLES, 0, 6);
 
         return this.flagReset();
@@ -582,13 +544,8 @@
         var opacity = elem._renderer.opacity || elem._opacity;
         var dashes = elem.dashes;
 
-        if (scale instanceof Two.Vector) {
-          canvas.width = Math.max(Math.ceil(elem._renderer.rect.width * scale.x), 1);
-          canvas.height = Math.max(Math.ceil(elem._renderer.rect.height * scale.y), 1);
-        } else {
-          canvas.width = Math.max(Math.ceil(elem._renderer.rect.width * scale), 1);
-          canvas.height = Math.max(Math.ceil(elem._renderer.rect.height * scale), 1);
-        }
+        canvas.width = Math.max(Math.ceil(elem._renderer.rect.width * scale.x), 1);
+        canvas.height = Math.max(Math.ceil(elem._renderer.rect.height * scale.y), 1);
 
         var centroid = elem._renderer.rect.centroid;
         var cx = centroid.x;
@@ -637,7 +594,7 @@
         }
 
         ctx.save();
-        ctx.scale(scale, scale);
+        ctx.scale(scale.x, scale.y);
         ctx.translate(cx, cy);
 
         if (!webgl.isHidden.test(fill)) {
@@ -828,16 +785,10 @@
             this._renderer.rect = {};
           }
 
-          if (!this._renderer.triangles) {
-            this._renderer.triangles = new Two.Array(12);
-          }
-
           this._renderer.opacity = this._opacity * parent._renderer.opacity;
 
           webgl.text.getBoundingClientRect(this, this._renderer.rect);
-          webgl.getTriangles(this._renderer.rect, this._renderer.triangles);
 
-          webgl.updateBuffer.call(webgl, gl, this, program);
           webgl.updateTexture.call(webgl, gl, this);
 
         } else {
@@ -862,22 +813,12 @@
         }
 
         // Draw Texture
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this._renderer.textureCoordsBuffer);
-
-        gl.vertexAttribPointer(program.textureCoords, 2, gl.FLOAT, false, 0, 0);
-
         gl.bindTexture(gl.TEXTURE_2D, this._renderer.texture);
 
-
         // Draw Rect
-
+        var rect = this._renderer.rect;
         gl.uniformMatrix3fv(program.matrix, false, this._renderer.matrix);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this._renderer.buffer);
-
-        gl.vertexAttribPointer(program.position, 2, gl.FLOAT, false, 0, 0);
-
+        gl.uniform4f(program.rect, rect.left, rect.top, rect.right, rect.bottom);
         gl.drawArrays(gl.TRIANGLES, 0, 6);
 
         return this.flagReset();
@@ -1011,50 +952,14 @@
 
     },
 
-    getTriangles: function(rect, triangles) {
-
-      var top = rect.top,
-          left = rect.left,
-          right = rect.right,
-          bottom = rect.bottom;
-
-      // First Triangle
-
-      triangles[0] = left;
-      triangles[1] = top;
-
-      triangles[2] = right;
-      triangles[3] = top;
-
-      triangles[4] = left;
-      triangles[5] = bottom;
-
-      // Second Triangle
-
-      triangles[6] = left;
-      triangles[7] = bottom;
-
-      triangles[8] = right;
-      triangles[9] = top;
-
-      triangles[10] = right;
-      triangles[11] = bottom;
-
-    },
-
     updateTexture: function(gl, elem) {
 
       this[elem._renderer.type].updateCanvas.call(webgl, elem);
 
-      if (elem._renderer.texture) {
-        gl.deleteTexture(elem._renderer.texture);
+      if (!elem._renderer.texture) {
+        elem._renderer.texture = gl.createTexture();
       }
 
-      gl.bindBuffer(gl.ARRAY_BUFFER, elem._renderer.textureCoordsBuffer);
-
-      // TODO: Is this necessary every time or can we do once?
-      // TODO: Create a registry for textures
-      elem._renderer.texture = gl.createTexture();
       gl.bindTexture(gl.TEXTURE_2D, elem._renderer.texture);
 
       // Set the parameters so we can render any size image.
@@ -1071,32 +976,6 @@
 
       // Upload the image into the texture.
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this.canvas);
-
-    },
-
-    updateBuffer: function(gl, elem, program) {
-
-      if (_.isObject(elem._renderer.buffer)) {
-        gl.deleteBuffer(elem._renderer.buffer);
-      }
-
-      elem._renderer.buffer = gl.createBuffer();
-
-      gl.bindBuffer(gl.ARRAY_BUFFER, elem._renderer.buffer);
-      gl.enableVertexAttribArray(program.position);
-
-      gl.bufferData(gl.ARRAY_BUFFER, elem._renderer.triangles, gl.STATIC_DRAW);
-
-      if (_.isObject(elem._renderer.textureCoordsBuffer)) {
-        gl.deleteBuffer(elem._renderer.textureCoordsBuffer);
-      }
-
-      elem._renderer.textureCoordsBuffer = gl.createBuffer();
-
-      gl.bindBuffer(gl.ARRAY_BUFFER, elem._renderer.textureCoordsBuffer);
-      gl.enableVertexAttribArray(program.textureCoords);
-
-      gl.bufferData(gl.ARRAY_BUFFER, this.uv, gl.STATIC_DRAW);
 
     },
 
@@ -1148,21 +1027,23 @@
       },
 
       vertex: [
+        'precision mediump float;',
         'attribute vec2 a_position;',
-        'attribute vec2 a_textureCoords;',
         '',
         'uniform mat3 u_matrix;',
         'uniform vec2 u_resolution;',
+        'uniform vec4 u_rect;',
         '',
         'varying vec2 v_textureCoords;',
         '',
         'void main() {',
-        '   vec2 projected = (u_matrix * vec3(a_position, 1.0)).xy;',
+        '   vec2 rectCoords = (a_position * (u_rect.zw - u_rect.xy)) + u_rect.xy;',
+        '   vec2 projected = (u_matrix * vec3(rectCoords, 1.0)).xy;',
         '   vec2 normal = projected / u_resolution;',
         '   vec2 clipspace = (normal * 2.0) - 1.0;',
         '',
         '   gl_Position = vec4(clipspace * vec2(1.0, -1.0), 0.0, 1.0);',
-        '   v_textureCoords = a_textureCoords;',
+        '   v_textureCoords = a_position;',
         '}'
       ].join('\n'),
 
@@ -1278,10 +1159,24 @@
     // look up where the vertex data needs to go.
     this.program.position = gl.getAttribLocation(this.program, 'a_position');
     this.program.matrix = gl.getUniformLocation(this.program, 'u_matrix');
-    this.program.textureCoords = gl.getAttribLocation(this.program, 'a_textureCoords');
+    this.program.rect = gl.getUniformLocation(this.program, 'u_rect');
 
-    // Copied from Three.js WebGLRenderer
-    gl.disable(gl.DEPTH_TEST);
+    // Bind the vertex buffer
+    var positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.vertexAttribPointer(this.program.position, 2, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(this.program.position);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([
+        0, 0,
+        1, 0,
+        0, 1,
+        0, 1,
+        1, 0,
+        1, 1
+      ]),
+      gl.STATIC_DRAW);
 
     // Setup some initial statements of the gl context
     gl.enable(gl.BLEND);
@@ -1357,7 +1252,7 @@
       var gl = this.ctx;
 
       if (!this.overdraw) {
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        gl.clear(gl.COLOR_BUFFER_BIT);
       }
 
       webgl.group.render.call(this.scene, gl, this.program);


### PR DESCRIPTION
- Fix canvas scaling like #416 did, but without the unnecessary checks.

- Remove [duplicate rendering loop](https://github.com/jonobr1/two.js/commit/12fd148ba38fbe472d625093253036543775e64f#diff-135ef49c47b024db0620d873c2fafeb5L133).
  - This fixes everything in a group being rendered twice. The duplicate loop was added in [this commit](https://github.com/jonobr1/two.js/commit/f9f4e42ce6d744fd8780415a93a94f16ae0acf24).

- Instead of creating a new buffer of triangles for every item, just use one.
  - This is done by passing the bounding rectangle into the shader as a uniform, and calculating the scale and position based on that, instead of initializing triangles to the proper rectangle scale in the buffer.
  - We can now bind this singular buffer once when the GL context is created. This obsoletes `getTriangles` and `updateBuffer`, which have been removed.

- Remove depth buffer stuff.
  - The depth buffer is never used (in fact, the WebGL context we acquire doesn't even have a depth buffer), so we don't need to clear it or disable depth testing (which is disabled by default regardless).