### PR TITLE
Remove Float32Array constructor from WebGL

### DIFF
--- a/src/renderer/webgl.js
+++ b/src/renderer/webgl.js
@@ -1161,7 +1161,7 @@
     gl.enableVertexAttribArray(this.program.position);
     gl.bufferData(
       gl.ARRAY_BUFFER,
-      new Float32Array([
+      new Two.Array([
         0, 0,
         1, 0,
         0, 1,


### PR DESCRIPTION
I missed this but the linter caught it.

`Float32Array`s are an ES6/ES2015 feature and are only supported in IE 10 and up.

I'm not sure what version of Internet Explorer two.js intends to target, but ESLint isn't currently set up to allow ES6 features, and this was the only usage of one in the codebase thus far.