### PR TITLE
Update/trim dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "eslint": "^6.7.2",
     "jsdoc": "~3.5.5",
     "jsdoc-to-markdown": "^4.0.1",
-    "moment": "^2.22.2",
     "node-minify": "^2.0.3",
     "qunit": "^2.9.3",
     "resemblejs": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -51,9 +51,11 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@node-minify/core": "^5.2.1",
+    "@node-minify/google-closure-compiler": "^5.2.1",
+    "@node-minify/no-compress": "^5.2.0",
     "eslint": "^6.7.2",
     "jsdoc": "~3.5.5",
-    "node-minify": "^2.0.3",
     "qunit": "^2.9.3",
     "resemblejs": "^3.2.3",
     "underscore": "^1.9.1"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jsdoc-to-markdown": "^4.0.1",
     "moment": "^2.22.2",
     "node-minify": "^2.0.3",
-    "qunitjs": "^2.4.0",
+    "qunit": "^2.9.3",
     "resemblejs": "^1.1.1",
     "underscore": "^1.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -51,11 +51,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "animation-frame": "^0.1.7",
-    "blueimp-canvas-to-blob": "^2.1.0",
     "eslint": "^6.7.2",
     "jsdoc": "~3.5.5",
-    "jsdoc-to-markdown": "^4.0.1",
     "node-minify": "^2.0.3",
     "qunit": "^2.9.3",
     "resemblejs": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "moment": "^2.22.2",
     "node-minify": "^2.0.3",
     "qunit": "^2.9.3",
-    "resemblejs": "^1.1.1",
+    "resemblejs": "^3.2.3",
     "underscore": "^1.9.1"
   },
   "autoupdate": {

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Two.js Tests</title>
-    <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
+    <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
   </head>
   <body>
     <div id="qunit"></div>
@@ -12,7 +12,7 @@
 
       <script src="../node_modules/resemblejs/resemble.js"></script>
       <script src="../node_modules/blueimp-canvas-to-blob/js/canvas-to-blob.js"></script>
-      <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
+      <script src="../node_modules/qunit/qunit/qunit.js"></script>
       <script src="../node_modules/underscore/underscore.js"></script>
 
       <!-- <script src="../build/two.js"></script> -->

--- a/tests/index.html
+++ b/tests/index.html
@@ -11,7 +11,6 @@
     <div class="scripts">
 
       <script src="../node_modules/resemblejs/resemble.js"></script>
-      <script src="../node_modules/blueimp-canvas-to-blob/js/canvas-to-blob.js"></script>
       <script src="../node_modules/qunit/qunit/qunit.js"></script>
       <script src="../node_modules/underscore/underscore.js"></script>
 

--- a/tests/noWebGL.html
+++ b/tests/noWebGL.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Two.js Tests sans WebGL</title>
-    <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
+    <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
   </head>
   <body>
     <div id="qunit"></div>
@@ -12,7 +12,7 @@
 
       <script src="../node_modules/resemblejs/resemble.js"></script>
       <script src="../node_modules/blueimp-canvas-to-blob/js/canvas-to-blob.js"></script>
-      <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
+      <script src="../node_modules/qunit/qunit/qunit.js"></script>
       <script src="../node_modules/underscore/underscore.js"></script>
 
       <script src="../build/two.js"></script>

--- a/tests/noWebGL.html
+++ b/tests/noWebGL.html
@@ -11,7 +11,6 @@
     <div class="scripts">
 
       <script src="../node_modules/resemblejs/resemble.js"></script>
-      <script src="../node_modules/blueimp-canvas-to-blob/js/canvas-to-blob.js"></script>
       <script src="../node_modules/qunit/qunit/qunit.js"></script>
       <script src="../node_modules/underscore/underscore.js"></script>
 

--- a/utils/build.js
+++ b/utils/build.js
@@ -1,9 +1,12 @@
 // https://npmjs.org/package/node-minify
 
 var path = require('path');
-var compressor = require('node-minify');
 var _ = require('underscore');
 var fs = require('fs');
+
+var minify = require('@node-minify/core');
+var noCompress = require('@node-minify/no-compress');
+var gcc = require('@node-minify/google-closure-compiler');
 
 var files = [
   path.resolve(__dirname, './start-comment.js'),
@@ -38,8 +41,8 @@ var files = [
 ];
 
 // Concatenated
-compressor.minify({
-  compressor: 'no-compress',
+minify({
+  compressor: noCompress,
   input: files,
   output: path.resolve(__dirname, '../build/two.js'),
   callback: function(e) {
@@ -59,8 +62,8 @@ compressor.minify({
       });
 
       // Minified
-      compressor.minify({
-        compressor: 'gcc',
+      minify({
+        compressor: gcc,
         input: path.resolve(__dirname, '../build/two.js'),
         output: path.resolve(__dirname, '../build/two.min.js'),
         callback: function(e) {
@@ -72,8 +75,8 @@ compressor.minify({
         }
       });
 
-      compressor.minify({
-        compressor: 'no-compress',
+      minify({
+        compressor: noCompress,
         input: [
           path.resolve(__dirname, '../build/two.js'),
           path.resolve(__dirname, './exports.js')

--- a/utils/build.js
+++ b/utils/build.js
@@ -4,7 +4,6 @@ var path = require('path');
 var compressor = require('node-minify');
 var _ = require('underscore');
 var fs = require('fs');
-var moment = require('moment');
 
 var files = [
   path.resolve(__dirname, './start-comment.js'),
@@ -53,7 +52,7 @@ compressor.minify({
       });
       var template = _.template(source);
       source = template({
-        publishDate: moment().format()
+        publishDate: (new Date()).toISOString()
       });
       fs.writeFileSync(path.resolve(__dirname, '../build/two.js'), source, {
         encoding: 'utf-8'


### PR DESCRIPTION
I've split this PR into 5 commits:

- Update QUnit
  - QUnit changed the name of their package from `qunitjs` to `qunit`. I've updated this where necessary.

- Update resemble.js
  - While it's undergone 2 major version bumps, tests which use it still seem to run properly.

- Remove moment.js
  - Moment.js was only used for formatting the publish date in the build process. I've replaced it with the `Date` object's `toISOString` method.
  - As a result, publish date timestamps will now be in UTC rather than the local timezone of the machine that the build was run on.

- Remove animation-frame, blueimp-canvas-to-blob, jsdoc-to-markdown
  - These dependencies appear to have been previously used for testing, but are no longer used.

- Update node-minify
  - node-minify has been [split into multiple small packages](https://github.com/srod/node-minify/blob/develop/Migrate.md). I've brought in the packages used by this project.