### PR TITLE
Use Terser instead of Closure Compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   "license": "MIT",
   "devDependencies": {
     "@node-minify/core": "^5.2.1",
-    "@node-minify/google-closure-compiler": "^5.2.1",
     "@node-minify/no-compress": "^5.2.0",
+    "@node-minify/terser": "^5.2.1",
     "eslint": "^6.7.2",
     "jsdoc": "~3.5.5",
     "qunit": "^2.9.3",

--- a/utils/build.js
+++ b/utils/build.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 
 var minify = require('@node-minify/core');
 var noCompress = require('@node-minify/no-compress');
-var gcc = require('@node-minify/google-closure-compiler');
+var terser = require('@node-minify/terser');
 
 var files = [
   path.resolve(__dirname, './start-comment.js'),
@@ -63,7 +63,7 @@ minify({
 
       // Minified
       minify({
-        compressor: gcc,
+        compressor: terser,
         input: path.resolve(__dirname, '../build/two.js'),
         output: path.resolve(__dirname, '../build/two.min.js'),
         callback: function(e) {


### PR DESCRIPTION
This was an oversight in #424, sorry!

Closure Compiler fails to parse custom JSDoc annotations and errors out (*despite the fact that they're comments...*)

Terser doesn't have those issues, and produces a very similar bundle size (actually ~2kb smaller) while also being much faster.