### PR TITLE
Fix masks in WebGL renderer being visible

### DIFF
--- a/src/renderers/webgl.js
+++ b/src/renderers/webgl.js
@@ -98,17 +98,19 @@ var webgl = {
       if (this._mask) {
 
         // Stencil away everything that isn't rendered by the mask
-
         gl.clear(gl.STENCIL_BUFFER_BIT);
         gl.enable(gl.STENCIL_TEST);
 
         gl.stencilFunc(gl.ALWAYS, 1, 0);
         gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
+        // Don't draw the element onto the canvas, only onto the stencil buffer
+        gl.colorMask(false, false, false, false);
 
         webgl[this._mask._renderer.type].render.call(this._mask, gl, program, this);
 
         gl.stencilFunc(gl.EQUAL, 1, 0xff);
         gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+        gl.colorMask(true, true, true, true);
 
       }
 


### PR DESCRIPTION
It turns out those `colorMask` calls in the WebGL masking code *were* necessary, but they should've been `colorMask(false, false, false, false)` (don't draw anything) instead of `colorMask(true, true, true, false)` (only draw alpha channel).

This makes masks in WebGL match the other renderers and not be visible.