### PR TITLE
Add GitHub Action for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,11 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install modules
+      run: npm install
+    - name: Run ESLint
+      run: npm run lint


### PR DESCRIPTION
This is mostly a test to see if GitHub will let me set up a GitHub Actions workflow on someone else's repo via a PR.

This adds a linting step to pull requests and pushes, which will result in commits/PRs being tagged with a checkmark if they pass linting and an "X" if they fail linting.

Currently, linting fails due to unnecessary regex escapes and a couple redeclared variables, but if this is merged, it should make it harder for such things to sneak into the codebase in the future.