### PR TITLE
Fix linting errors

### DIFF
--- a/src/utils/interpret-svg.js
+++ b/src/utils/interpret-svg.js
@@ -157,7 +157,7 @@ var applySvgViewBox = function(node, value) {
 };
 
 var extrapolateScientificNotation = function(command) {
-  var regex = /[\+\-]?[\d\.]*e[\-\+]?\d*/ig;
+  var regex = /[+-]?[\d.]*e[-+]?\d*/ig;
   var matches = command.match(regex);
   if (matches && matches.length > 0) {
     for (var i = 0; i < matches.length; i++) {
@@ -182,7 +182,7 @@ var extrapolateScientificNotation = function(command) {
  */
 var applySvgAttributes = function(node, elem, parentStyles) {
 
-  var  styles = {}, attributes = {}, extracted = {}, i, key, value, attr;
+  var  styles = {}, attributes = {}, extracted = {}, i, m, key, value, attr;
 
   // Not available in non browser environments
   if (root.getComputedStyle) {
@@ -239,7 +239,7 @@ var applySvgAttributes = function(node, elem, parentStyles) {
       case 'transform':
         // TODO: Check this out https://github.com/paperjs/paper.js/blob/develop/src/svg/SvgImport.js#L315
         if (/none/i.test(value)) break;
-        var m = (node.transform && node.transform.baseVal && node.transform.baseVal.length > 0)
+        m = (node.transform && node.transform.baseVal && node.transform.baseVal.length > 0)
           ? node.transform.baseVal[0].matrix
           : (node.getCTM ? node.getCTM() : null);
 
@@ -270,7 +270,7 @@ var applySvgAttributes = function(node, elem, parentStyles) {
         } else {
 
           // Edit the underlying matrix and don't force an auto calc.
-          var m = node.getCTM();
+          m = node.getCTM();
           elem._matrix.manual = true;
           elem._matrix.set(m.a, m.b, m.c, m.d, m.e, m.f);
 
@@ -469,16 +469,17 @@ var read = {
 
   use: function(node, styles) {
 
+    var error;
     var href = node.getAttribute('href') || node.getAttribute('xlink:href');
     if (!href) {
-      var error = new TwoError('encountered <use /> with no href.');
+      error = new TwoError('encountered <use /> with no href.');
       console.warn(error.name, error.message);
       return null;
     }
 
     var id = href.slice(1);
     if (!read.defs.current.contains(id)) {
-      var error = new TwoError(
+      error = new TwoError(
         'unable to find element for reference ' + href + '.');
       console.warn(error.name, error.message);
       return null;
@@ -538,7 +539,7 @@ var read = {
     var points = node.getAttribute('points');
 
     var verts = [];
-    points.replace(/(-?[\d\.eE-]+)[,|\s](-?[\d\.eE-]+)/g, function(match, p1, p2) {
+    points.replace(/(-?[\d.eE-]+)[,|\s](-?[\d.eE-]+)/g, function(match, p1, p2) {
       verts.push(new Anchor(parseFloat(p1), parseFloat(p2)));
     });
 

--- a/utils/build.js
+++ b/utils/build.js
@@ -2,7 +2,7 @@ var rollup = require('rollup');
 var fs = require('fs');
 var path = require('path');
 var _ = require('underscore');
-var gzip = require('gzip-size')
+var gzip = require('gzip-size');
 var terser = require('rollup-plugin-terser').terser;
 
 var publishDateString = (new Date()).toISOString();

--- a/utils/document.js
+++ b/utils/document.js
@@ -61,7 +61,7 @@ _.each(sourceFiles, function(file) {
   };
 
   _.each(citations, function(citation) {
-    if (/\#/i.test(citation.longname)) {
+    if (/#/i.test(citation.longname)) {
       citationsByScope.instance.push(citation);
     } else {
       citationsByScope.static.push(citation);
@@ -150,7 +150,7 @@ function expandLink(object, property) {
 
   if (value) {
 
-    var regex = /\{\@link ([\w\d\:\/\?\-\.\#]*)\}/i;
+    var regex = /\{@link ([\w\d:/?\-.#]*)\}/i;
     var link = value.match(regex);
 
     if (link && link.length > 1) {
@@ -164,7 +164,7 @@ function expandLink(object, property) {
 
       } else {
 
-        var fragments = name.split(/[\.\#]/i);
+        var fragments = name.split(/[.#]/i);
 
         var directory = fragments[1] || '';
         var hash = fragments.length > 2 ? fragments.join('-') : '';


### PR DESCRIPTION
This should now make the linting action pass.

Hoisting the `error` and `m` variables out of the block scopes is a bit ugly-looking but makes things more clear (JS already hoists these variables to the function scope behind-the-scenes). ES6's `let` and `const` keywords will allow for proper block-scoped variable declarations but aren't yet in use in the codebase--my other issue details that a bit more.