### PR TITLE
Add skewX and skewY properties to Shape

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -704,6 +704,8 @@ _.extend(Path.prototype, Shape.prototype, {
     clone.translation.copy(this.translation);
     clone.rotation = this.rotation;
     clone.scale = this.scale;
+    clone.skewX = this.skewX;
+    clone.skewY = this.skewY;
 
     if (this.matrix.manual) {
       clone.matrix.copy(this.matrix);
@@ -740,6 +742,8 @@ _.extend(Path.prototype, Shape.prototype, {
     result.translation = this.translation.toObject();
     result.rotation = this.rotation;
     result.scale = this.scale instanceof Vector ? this.scale.toObject() : this.scale;
+    result.skewX = this.skewX;
+    result.skewY = this.skewY;
 
     if (this.matrix.manual) {
       result.matrix = this.matrix.toObject();

--- a/src/shape.js
+++ b/src/shape.js
@@ -43,7 +43,7 @@ var Shape = function() {
    * @name Two.Shape#matrix
    * @property {Two.Matrix}
    * @description The transformation matrix of the shape.
-   * @nota-bene {@link Two.Shape#translation}, {@link Two.Shape#rotation}, and {@link Two.Shape#scale} apply their values to the matrix when changed. The matrix is what is sent to the renderer to be drawn.
+   * @nota-bene {@link Two.Shape#translation}, {@link Two.Shape#rotation}, {@link Two.Shape#scale}, {@link Two.Shape#skewX}, and {@link Two.Shape#skewY} apply their values to the matrix when changed. The matrix is what is sent to the renderer to be drawn.
    */
   this.matrix = new Matrix();
 
@@ -65,6 +65,20 @@ var Shape = function() {
    * @nota-bene This value can be replaced with a {@link Two.Vector} to do non-uniform scaling. e.g: `shape.scale = new Two.Vector(2, 1);`
    */
   this.scale = 1;
+
+  /**
+   * @name Two.Shape#skewX
+   * @property {Radians} - The value in radians for how much the shape is skewed relative to its parent.
+   * @description Skew the shape by an angle in the x axis direction.
+   */
+  this.skewX = 0;
+
+  /**
+   * @name Two.Shape#skewY
+   * @property {Radians} - The value in radians for how much the shape is skewed relative to its parent.
+   * @description Skew the shape by an angle in the y axis direction.
+   */
+  this.skewY = 0;
 
 };
 
@@ -136,6 +150,28 @@ _.extend(Shape, {
         this._flagMatrix = true;
         this._flagScale = true;
 
+      }
+    });
+
+    Object.defineProperty(object, 'skewX', {
+      enumerable: true,
+      get: function() {
+        return this._skewX;
+      },
+      set: function(v) {
+        this._skewX = v;
+        this._flagMatrix = true;
+      }
+    });
+
+    Object.defineProperty(object, 'skewY', {
+      enumerable: true,
+      get: function() {
+        return this._skewY;
+      },
+      set: function(v) {
+        this._skewY = v;
+        this._flagMatrix = true;
       }
     });
 
@@ -240,6 +276,20 @@ _.extend(Shape.prototype, Events, {
    */
   _scale: 1,
 
+  /**
+   * @name Two.Shape#_skewX
+   * @private
+   * @property {Radians} - The rotation value in radians.
+   */
+  _skewX: 0,
+
+  /**
+   * @name Two.Shape#_skewY
+   * @private
+   * @property {Radians} - The rotation value in radians.
+   */
+  _skewY: 0,
+
   // _mask: null,
   // _clip: false,
 
@@ -277,6 +327,8 @@ _.extend(Shape.prototype, Events, {
     clone.translation.copy(this.translation);
     clone.rotation = this.rotation;
     clone.scale = this.scale;
+    clone.skewX = this.skewX;
+    clone.skewY = this.skewY;
 
     if (this.matrix.manual) {
       clone.matrix.copy(this.matrix);
@@ -313,7 +365,8 @@ _.extend(Shape.prototype, Events, {
         }
 
         this._matrix.rotate(this.rotation);
-
+        this._matrix.skewX(this.skewX);
+        this._matrix.skewY(this.skewY);
     }
 
     if (bubbles) {

--- a/src/shapes/arc-segment.js
+++ b/src/shapes/arc-segment.js
@@ -331,6 +331,8 @@ _.extend(ArcSegment.prototype, Path.prototype, {
     clone.translation.copy(this.translation);
     clone.rotation = this.rotation;
     clone.scale = this.scale;
+    clone.skewX = this.skewX;
+    clone.skewY = this.skewY;
 
     if (this.matrix.manual) {
       clone.matrix.copy(this.matrix);

--- a/src/shapes/circle.js
+++ b/src/shapes/circle.js
@@ -160,6 +160,8 @@ _.extend(Circle.prototype, Path.prototype, {
     clone.translation.copy(this.translation);
     clone.rotation = this.rotation;
     clone.scale = this.scale;
+    clone.skewX = this.skewX;
+    clone.skewY = this.skewY;
 
     if (this.matrix.manual) {
       clone.matrix.copy(this.matrix);

--- a/src/shapes/ellipse.js
+++ b/src/shapes/ellipse.js
@@ -178,6 +178,8 @@ _.extend(Ellipse.prototype, Path.prototype, {
     clone.translation.copy(this.translation);
     clone.rotation = this.rotation;
     clone.scale = this.scale;
+    clone.skewX = this.skewX;
+    clone.skewY = this.skewY;
 
     if (this.matrix.manual) {
       clone.matrix.copy(this.matrix);

--- a/src/shapes/polygon.js
+++ b/src/shapes/polygon.js
@@ -186,6 +186,8 @@ _.extend(Polygon.prototype, Path.prototype, {
     clone.translation.copy(this.translation);
     clone.rotation = this.rotation;
     clone.scale = this.scale;
+    clone.skewX = this.skewX;
+    clone.skewY = this.skewY;
 
     if (this.matrix.manual) {
       clone.matrix.copy(this.matrix);

--- a/src/shapes/rectangle.js
+++ b/src/shapes/rectangle.js
@@ -179,6 +179,8 @@ _.extend(Rectangle.prototype, Path.prototype, {
     clone.translation.copy(this.translation);
     clone.rotation = this.rotation;
     clone.scale = this.scale;
+    clone.skewX = this.skewX;
+    clone.skewY = this.skewY;
 
     if (this.matrix.manual) {
       clone.matrix.copy(this.matrix);

--- a/src/shapes/rounded-rectangle.js
+++ b/src/shapes/rounded-rectangle.js
@@ -296,6 +296,8 @@ _.extend(RoundedRectangle.prototype, Path.prototype, {
     clone.translation.copy(this.translation);
     clone.rotation = this.rotation;
     clone.scale = this.scale;
+    clone.skewX = this.skewX;
+    clone.skewY = this.skewY;
 
     if (this.matrix.manual) {
       clone.matrix.copy(this.matrix);

--- a/src/shapes/star.js
+++ b/src/shapes/star.js
@@ -201,6 +201,8 @@ _.extend(Star.prototype, Path.prototype, {
     clone.translation.copy(this.translation);
     clone.rotation = this.rotation;
     clone.scale = this.scale;
+    clone.skewX = this.skewX;
+    clone.skewY = this.skewY;
 
     if (this.matrix.manual) {
       clone.matrix.copy(this.matrix);


### PR DESCRIPTION
there's translation, rotation, and scale properties that manipulate the matrix transforms on Shape but it's missing skewX and skewY. In order to apply these matrix transforms you have to enter manual matrix mode, which is a pain for code maintenance, animations, especially when dealing with groups (IMO). This allows skewX and skewY to be set on anything that inherits from Shape for convenience.

Example usage:
```
var rect = new Two.RoundedRectangle(0, 0, 100, 200, 20);
rect.skewX = Math.PI/2;
rect.skewY = Math.PI/4;
```