### PR TITLE
Short circuit renderer updates on invisible elements

### DIFF
--- a/src/renderers/canvas.js
+++ b/src/renderers/canvas.js
@@ -56,12 +56,11 @@ var canvas = {
 
     render: function(ctx) {
 
-      // TODO: Add a check here to only invoke _update if need be.
-      this._update();
-
       if (!this._visible) {
         return this;
       }
+
+      this._update();
 
       var matrix = this._matrix.elements;
       var parent = this.parent;
@@ -126,15 +125,21 @@ var canvas = {
           closed, commands, length, last, next, prev, a, b, c, d, ux, uy, vx, vy,
           ar, bl, br, cl, x, y, mask, clip, defaultMatrix, isOffset, dashes;
 
-      // TODO: Add a check here to only invoke _update if need be.
+      // mask = this._mask;
+      clip = this._clip;
+      opacity = this._opacity * this.parent._renderer.opacity;
+      visible = this._visible;
+
+      if (!forced && (!visible || clip || opacity === 0)) {
+        return this;
+      }
+
       this._update();
 
       matrix = this._matrix.elements;
       stroke = this._stroke;
       linewidth = this._linewidth;
       fill = this._fill;
-      opacity = this._opacity * this.parent._renderer.opacity;
-      visible = this._visible;
       cap = this._cap;
       join = this._join;
       miter = this._miter;
@@ -144,13 +149,6 @@ var canvas = {
       last = length - 1;
       defaultMatrix = isDefaultMatrix(matrix);
       dashes = this.dashes;
-
-      // mask = this._mask;
-      clip = this._clip;
-
-      if (!forced && (!visible || clip)) {
-        return this;
-      }
 
       // Transform
       if (!defaultMatrix) {
@@ -366,7 +364,15 @@ var canvas = {
 
     render: function(ctx, forced, parentClipped) {
 
-      // TODO: Add a check here to only invoke _update if need be.
+      var opacity = this._opacity * this.parent._renderer.opacity;
+      var visible = this._visible;
+      // mask = this._mask;
+      var clip = this._clip;
+
+      if (!forced && (!visible || clip || opacity === 0)) {
+        return this;
+      }
+
       this._update();
 
       var matrix = this._matrix.elements;
@@ -374,8 +380,6 @@ var canvas = {
       var linewidth = this._linewidth;
       var fill = this._fill;
       var decoration = this._decoration;
-      var opacity = this._opacity * this.parent._renderer.opacity;
-      var visible = this._visible;
       var defaultMatrix = isDefaultMatrix(matrix);
       var isOffset = fill._renderer && fill._renderer.offset
         && stroke._renderer && stroke._renderer.offset;
@@ -384,13 +388,6 @@ var canvas = {
       var baseline = this._baseline;
 
       var a, b, c, d, e, sx, sy, x1, y1, x2, y2;
-
-      // mask = this._mask;
-      var clip = this._clip;
-
-      if (!forced && (!visible || clip)) {
-        return this;
-      }
 
       // Transform
       if (!defaultMatrix) {

--- a/src/renderers/svg.js
+++ b/src/renderers/svg.js
@@ -263,8 +263,6 @@ var svg = {
 
     render: function(domElement) {
 
-      this._update();
-
       // Shortcut for hidden objects.
       // Doesn't reset the flags, so changes are stored and
       // applied once the object is visible again
@@ -272,6 +270,8 @@ var svg = {
         || (this._opacity === 0 && !this._flagOpacity)) {
         return this;
       }
+
+      this._update();
 
       if (!this._renderer.elem) {
         this._renderer.elem = svg.createElement('g', {
@@ -359,14 +359,14 @@ var svg = {
 
     render: function(domElement) {
 
-      this._update();
-
       // Shortcut for hidden objects.
       // Doesn't reset the flags, so changes are stored and
       // applied once the object is visible again
       if (this._opacity === 0 && !this._flagOpacity) {
         return this;
       }
+
+      this._update();
 
       // Collect any attribute that needs to be changed here
       var changed = {};

--- a/src/renderers/webgl.js
+++ b/src/renderers/webgl.js
@@ -55,11 +55,11 @@ var webgl = {
 
     render: function(gl, program) {
 
-      this._update();
-
       if (!this._visible) {
         return;
       }
+
+      this._update();
 
       var parent = this.parent;
       var flagParentMatrix = (parent._matrix && parent._matrix.manual) || parent._flagMatrix;


### PR DESCRIPTION
Speed up rendering the scene when handling invisible (`opacity = 0` or `visible = false`) elements. We don't need to run `_update` methods on invisible objects. When they become visible, then run the `_update` method like usual. This greatly improves performance on scenes where there are a large number of elements on or off the screen and some are not visible.

This is a step towards optimizations for #363

Context: In our project using Two.js, we're using the hack way of frustum culling suggested in #363 (looping through children, figuring out if it's visible on screen --- except not using getBoundingClientRect because that tanks performance --- and setting `visible = true` or `visible = false`), but we still ran into performance issues with lots of hidden elements that aren't on the screen because the `_update` function is still being called, applying matrix manipulations, house keeping, etc. to these invisible elements that are way off the screen. On our end, frustum culling in this way along with this short circuit visibility renderer fix improves performance from 6fps to 60fps. Pretty big gains.

👀  would be great to get your eyes on the change diff. Perhaps there's other optimizations in the renderer that would further increase performance, or I might have missed some short circuit opportunities.