### PR TITLE
Enhancing Two.Gradient & Two.interpret

### DIFF
--- a/src/effects/gradient.js
+++ b/src/effects/gradient.js
@@ -44,10 +44,10 @@ function Gradient(stops) {
 
   /**
    * @name Two.Gradient#units
-   * @property {String} [units='userSpaceOnUse'] - Indicates how coordinate values are interpreted by the renderer. Possible values are `'userSpaceOnUse'` and `'objectBoundingBox'`.
+   * @property {String} [units='objectBoundingBox'] - Indicates how coordinate values are interpreted by the renderer. Possible values are `'userSpaceOnUse'` and `'objectBoundingBox'`.
    * @see {@link https://www.w3.org/TR/SVG11/pservers.html#RadialGradientElementGradientUnitsAttribute} for more information
    */
-  this.units = 'userSpaceOnUse';
+  this.units = 'objectBoundingBox';
 
   /**
    * @name Two.Gradient#stops

--- a/src/effects/gradient.js
+++ b/src/effects/gradient.js
@@ -37,10 +37,17 @@ function Gradient(stops) {
 
   /**
    * @name Two.Gradient#spread
-   * @property {String} - Indicates what happens if the gradient starts or ends inside the bounds of the target rectangle. Possible values are `'pad'`, `'reflect'`, and `'repeat'`.
+   * @property {String} [spread='pad'] - Indicates what happens if the gradient starts or ends inside the bounds of the target rectangle. Possible values are `'pad'`, `'reflect'`, and `'repeat'`.
    * @see {@link https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementSpreadMethodAttribute} for more information
    */
   this.spread = 'pad';
+
+  /**
+   * @name Two.Gradient#units
+   * @property {String} [units='userSpaceOnUse'] - Indicates how coordinate values are interpreted by the renderer. Possible values are `'userSpaceOnUse'` and `'objectBoundingBox'`.
+   * @see {@link https://www.w3.org/TR/SVG11/pservers.html#RadialGradientElementGradientUnitsAttribute} for more information
+   */
+  this.units = 'userSpaceOnUse';
 
   /**
    * @name Two.Gradient#stops
@@ -65,7 +72,7 @@ _.extend(Gradient, {
    * @property {String[]} - A list of properties that are on every {@link Two.Gradient}.
    */
   Properties: [
-    'spread'
+    'spread', 'units'
   ],
 
   /**
@@ -213,8 +220,16 @@ _.extend(Gradient.prototype, Events, {
    * @property {Boolean} - Determines whether the {@link Two.Gradient#spread} needs updating.
    */
   _flagSpread: false,
+  /**
+   * @name Two.Gradient#_flagUnits
+   * @private
+   * @property {Boolean} - Determins whether the {@link Two.Gradient#units} needs updating.
+   */
+  _flagUnits: false,
 
   _id: '',
+  _spread: '',
+  _units: '',
 
   /**
    * @name Two.Gradient#clone
@@ -291,7 +306,7 @@ _.extend(Gradient.prototype, Events, {
    */
   flagReset: function() {
 
-    this._flagSpread = this._flagStops = false;
+    this._flagSpread = this._flagUnits = this._flagStops = false;
 
     return this;
 

--- a/src/renderers/canvas.js
+++ b/src/renderers/canvas.js
@@ -759,6 +759,7 @@ var canvas = {
       if (!this._renderer.effect || this._flagCenter || this._flagFocal
           || this._flagRadius || this._flagStops || this._flagUnits) {
 
+        var rect;
         var cx = this.center._x;
         var cy = this.center._y;
         var fx = this.focal._x;

--- a/src/renderers/canvas.js
+++ b/src/renderers/canvas.js
@@ -172,7 +172,7 @@ var canvas = {
         if (typeof fill === 'string') {
           ctx.fillStyle = fill;
         } else {
-          canvas[fill._renderer.type].render.call(fill, ctx);
+          canvas[fill._renderer.type].render.call(fill, ctx, this);
           ctx.fillStyle = fill._renderer.effect;
         }
       }
@@ -180,7 +180,7 @@ var canvas = {
         if (typeof stroke === 'string') {
           ctx.strokeStyle = stroke;
         } else {
-          canvas[stroke._renderer.type].render.call(stroke, ctx);
+          canvas[stroke._renderer.type].render.call(stroke, ctx, this);
           ctx.strokeStyle = stroke._renderer.effect;
         }
         if (linewidth) {
@@ -401,7 +401,7 @@ var canvas = {
         if (typeof fill === 'string') {
           ctx.fillStyle = fill;
         } else {
-          canvas[fill._renderer.type].render.call(fill, ctx);
+          canvas[fill._renderer.type].render.call(fill, ctx, this);
           ctx.fillStyle = fill._renderer.effect;
         }
       }
@@ -409,7 +409,7 @@ var canvas = {
         if (typeof stroke === 'string') {
           ctx.strokeStyle = stroke;
         } else {
-          canvas[stroke._renderer.type].render.call(stroke, ctx);
+          canvas[stroke._renderer.type].render.call(stroke, ctx, this);
           ctx.strokeStyle = stroke._renderer.effect;
         }
         if (linewidth) {
@@ -551,7 +551,7 @@ var canvas = {
         if (typeof fill === 'string') {
           ctx.fillStyle = fill;
         } else {
-          canvas[fill._renderer.type].render.call(fill, ctx);
+          canvas[fill._renderer.type].render.call(fill, ctx, this);
           ctx.fillStyle = fill._renderer.effect;
         }
       }
@@ -559,7 +559,7 @@ var canvas = {
         if (typeof stroke === 'string') {
           ctx.strokeStyle = stroke;
         } else {
-          canvas[stroke._renderer.type].render.call(stroke, ctx);
+          canvas[stroke._renderer.type].render.call(stroke, ctx, this);
           ctx.strokeStyle = stroke._renderer.effect;
         }
         if (linewidth) {
@@ -713,16 +713,29 @@ var canvas = {
 
   'linear-gradient': {
 
-    render: function(ctx) {
+    render: function(ctx, parent) {
 
       this._update();
 
-      if (!this._renderer.effect || this._flagEndPoints || this._flagStops) {
+      if (!this._renderer.effect || this._flagEndPoints || this._flagStops
+        || this._flagUnits) {
 
-        this._renderer.effect = ctx.createLinearGradient(
-          this.left._x, this.left._y,
-          this.right._x, this.right._y
-        );
+        var rect;
+        var lx = this.left._x;
+        var ly = this.left._y;
+        var rx = this.right._x;
+        var ry = this.right._y;
+
+        if (/objectBoundingBox/i.test(this._units)) {
+          // Convert objectBoundingBox units to userSpaceOnUse units
+          rect = parent.getBoundingClientRect(true);
+          lx = (lx - 0.5) * rect.width;
+          ly = (ly - 0.5) * rect.height;
+          rx = (rx - 0.5) * rect.width;
+          ry = (ry - 0.5) * rect.height;
+        }
+
+        this._renderer.effect = ctx.createLinearGradient(lx, ly, rx, ry);
 
         for (var i = 0; i < this.stops.length; i++) {
           var stop = this.stops[i];
@@ -739,17 +752,29 @@ var canvas = {
 
   'radial-gradient': {
 
-    render: function(ctx) {
+    render: function(ctx, parent) {
 
       this._update();
 
       if (!this._renderer.effect || this._flagCenter || this._flagFocal
-          || this._flagRadius || this._flagStops) {
+          || this._flagRadius || this._flagStops || this._flagUnits) {
 
-        this._renderer.effect = ctx.createRadialGradient(
-          this.center._x, this.center._y, 0,
-          this.focal._x, this.focal._y, this._radius
-        );
+        var cx = this.center._x;
+        var cy = this.center._y;
+        var fx = this.focal._x;
+        var fy = this.focal._y;
+
+        if (/objectBoundingBox/i.test(this._units)) {
+          // Convert objectBoundingBox units to userSpaceOnUse units
+          rect = parent.getBoundingClientRect(true);
+          cx = (cx - 0.5) * rect.width;
+          cy = (cy - 0.5) * rect.height;
+          fx = (fx - 0.5) * rect.width;
+          fy = (fy - 0.5) * rect.height;
+        }
+
+        this._renderer.effect = ctx.createRadialGradient(cx, cy,
+          0, fx, fy, this._radius);
 
         for (var i = 0; i < this.stops.length; i++) {
           var stop = this.stops[i];

--- a/src/renderers/svg.js
+++ b/src/renderers/svg.js
@@ -762,12 +762,15 @@ var svg = {
         changed.spreadMethod = this._spread;
       }
 
+      if (this._flagUnits) {
+        changed.gradientUnits = this._units;
+      }
+
       // If there is no attached DOM element yet,
       // create it with all necessary attributes.
       if (!this._renderer.elem) {
 
         changed.id = this._id;
-        changed.gradientUnits = 'userSpaceOnUse';
         this._renderer.elem = svg.createElement('linearGradient', changed);
         domElement.defs.appendChild(this._renderer.elem);
 
@@ -856,12 +859,15 @@ var svg = {
         changed.spreadMethod = this._spread;
       }
 
+      if (this._flagUnits) {
+        changed.gradientUnits = this._units;
+      }
+
       // If there is no attached DOM element yet,
       // create it with all necessary attributes.
       if (!this._renderer.elem) {
 
         changed.id = this._id;
-        changed.gradientUnits = 'userSpaceOnUse';
         this._renderer.elem = svg.createElement('radialGradient', changed);
         domElement.defs.appendChild(this._renderer.elem);
 

--- a/src/renderers/webgl.js
+++ b/src/renderers/webgl.js
@@ -1294,6 +1294,7 @@ var webgl = {
       if (!this._renderer.effect || this._flagCenter || this._flagFocal
           || this._flagRadius || this._flagStops || this._flagUnits) {
 
+        var rect;
         var cx = this.center._x;
         var cy = this.center._y;
         var fx = this.focal._x;

--- a/src/renderers/webgl.js
+++ b/src/renderers/webgl.js
@@ -1240,7 +1240,7 @@ var webgl = {
 
   'linear-gradient': {
 
-    render: function(ctx, elem) {
+    render: function(ctx, parent) {
 
       if (!ctx.canvas.getContext('2d')) {
         return;
@@ -1248,12 +1248,25 @@ var webgl = {
 
       this._update();
 
-      if (!this._renderer.effect || this._flagEndPoints || this._flagStops) {
+      if (!this._renderer.effect || this._flagEndPoints || this._flagStops
+        || this._flagUnits) {
 
-        this._renderer.effect = ctx.createLinearGradient(
-          this.left._x, this.left._y,
-          this.right._x, this.right._y
-        );
+        var rect;
+        var lx = this.left._x;
+        var ly = this.left._y;
+        var rx = this.right._x;
+        var ry = this.right._y;
+
+        if (/objectBoundingBox/i.test(this._units)) {
+          // Convert objectBoundingBox units to userSpaceOnUse units
+          rect = parent.getBoundingClientRect(true);
+          lx = (lx - 0.5) * rect.width;
+          ly = (ly - 0.5) * rect.height;
+          rx = (rx - 0.5) * rect.width;
+          ry = (ry - 0.5) * rect.height;
+        }
+
+        this._renderer.effect = ctx.createLinearGradient(lx, ly, rx, ry);
 
         for (var i = 0; i < this.stops.length; i++) {
           var stop = this.stops[i];
@@ -1270,7 +1283,7 @@ var webgl = {
 
   'radial-gradient': {
 
-    render: function(ctx, elem) {
+    render: function(ctx, parent) {
 
       if (!ctx.canvas.getContext('2d')) {
         return;
@@ -1279,12 +1292,24 @@ var webgl = {
       this._update();
 
       if (!this._renderer.effect || this._flagCenter || this._flagFocal
-          || this._flagRadius || this._flagStops) {
+          || this._flagRadius || this._flagStops || this._flagUnits) {
 
-        this._renderer.effect = ctx.createRadialGradient(
-          this.center._x, this.center._y, 0,
-          this.focal._x, this.focal._y, this._radius
-        );
+        var cx = this.center._x;
+        var cy = this.center._y;
+        var fx = this.focal._x;
+        var fy = this.focal._y;
+
+        if (/objectBoundingBox/i.test(this._units)) {
+          // Convert objectBoundingBox units to userSpaceOnUse units
+          rect = parent.getBoundingClientRect(true);
+          cx = (cx - 0.5) * rect.width;
+          cy = (cy - 0.5) * rect.height;
+          fx = (fx - 0.5) * rect.width;
+          fy = (fy - 0.5) * rect.height;
+        }
+
+        this._renderer.effect = ctx.createRadialGradient(cx, cy,
+          0, fx, fy, this._radius);
 
         for (var i = 0; i < this.stops.length; i++) {
           var stop = this.stops[i];

--- a/src/utils/interpret-svg.js
+++ b/src/utils/interpret-svg.js
@@ -29,6 +29,7 @@ import Constants from '../constants.js';
 // https://github.com/jonobr1/two.js/issues/507#issuecomment-777159213
 var regex = {
   path: /[+-]?(?:\d*\.\d+|\d+)(?:[eE][+-]\d+)?/g,
+  cssBackgroundImage: /url\(['"]?#(.*)['"]?\)/i,
   unitSuffix: /[a-zA-Z%]*/i
 };
 
@@ -399,8 +400,8 @@ var applySvgAttributes = function(node, elem, parentStyles) {
         elem.opacity = parseFloat(value);
         break;
       case 'clip-path':
-        if (/url\(#.*\)/i.test(value)) {
-          id = value.replace(/url\(#(.*)\)/i, '$1');
+        if (regex.cssBackgroundImage.test(value)) {
+          id = value.replace(regex.cssBackgroundImage, '$1');
           if (read.defs.current && read.defs.current.contains(id)) {
             ref = read.defs.current.get(id);
             if (ref && ref.childNodes.length > 0) {
@@ -423,9 +424,8 @@ var applySvgAttributes = function(node, elem, parentStyles) {
       case 'fill':
       case 'stroke':
         prop = (elem instanceof Group ? '_' : '') + key;
-        if (/url\(#.*\)/i.test(value)) {
-          id = value.replace(/url\(#(.*)\)/i, '$1');
-          node.setAttribute(key, value.replace(/\)/i, '-' + Constants.Identifier + 'applied)'));
+        if (regex.cssBackgroundImage.test(value)) {
+          id = value.replace(regex.cssBackgroundImage, '$1');
           if (read.defs.current && read.defs.current.contains(id)) {
             ref = read.defs.current.get(id);
             tagName = getTagName(ref.nodeName);

--- a/src/utils/interpret-svg.js
+++ b/src/utils/interpret-svg.js
@@ -29,7 +29,7 @@ import Constants from '../constants.js';
 // https://github.com/jonobr1/two.js/issues/507#issuecomment-777159213
 var regex = {
   path: /[+-]?(?:\d*\.\d+|\d+)(?:[eE][+-]\d+)?/g,
-  cssBackgroundImage: /url\(['"]?#(.*)['"]?\)/i,
+  cssBackgroundImage: /url\(['"]?#([\w\d-_]*)['"]?\)/i,
   unitSuffix: /[a-zA-Z%]*/i
 };
 
@@ -426,10 +426,16 @@ var applySvgAttributes = function(node, elem, parentStyles) {
         prop = (elem instanceof Group ? '_' : '') + key;
         if (regex.cssBackgroundImage.test(value)) {
           id = value.replace(regex.cssBackgroundImage, '$1');
+          // Overwritten id for non-conflicts on same page SVG documents
+          // TODO: Make this non-descructive
+          // node.setAttribute('two-' + key, value.replace(/\)/i, '-' + Constants.Identifier + 'applied)'));
           if (read.defs.current && read.defs.current.contains(id)) {
             ref = read.defs.current.get(id);
-            tagName = getTagName(ref.nodeName);
-            ref = read[tagName].call(this, ref, {});
+            if (!ref.object) {
+              tagName = getTagName(ref.nodeName);
+              ref.object = read[tagName].call(this, ref, {});
+            }
+            ref = ref.object;
           } else {
             scene = getScene(this);
             ref = scene.getById(id);
@@ -443,7 +449,7 @@ var applySvgAttributes = function(node, elem, parentStyles) {
         elem.id = value;
         // Overwritten id for non-conflicts on same page SVG documents
         // TODO: Make this non-descructive
-        node.id = value + '-' + Constants.Identifier + 'applied';
+        // node.id = value + '-' + Constants.Identifier + 'applied';
         break;
       case 'class':
       case 'className':

--- a/src/utils/interpret-svg.js
+++ b/src/utils/interpret-svg.js
@@ -1168,10 +1168,10 @@ var read = {
 
   lineargradient: function(node, parentStyles) {
 
-    var x1 = parseFloat(node.getAttribute('x1'));
-    var y1 = parseFloat(node.getAttribute('y1'));
-    var x2 = parseFloat(node.getAttribute('x2'));
-    var y2 = parseFloat(node.getAttribute('y2'));
+    var x1 = parseFloat(node.getAttribute('x1') || 0);
+    var y1 = parseFloat(node.getAttribute('y1') || 0);
+    var x2 = parseFloat(node.getAttribute('x2') || 0);
+    var y2 = parseFloat(node.getAttribute('y2') || 0);
 
     var ox = (x2 + x1) / 2;
     var oy = (y2 + y1) / 2;

--- a/src/utils/interpret-svg.js
+++ b/src/utils/interpret-svg.js
@@ -1174,6 +1174,16 @@ var read = {
 
   lineargradient: function(node, parentStyles) {
 
+    var units = node.getAttribute('gradientUnits');
+    var spread = node.getAttribute('spreadMethod');
+
+    if (!units) {
+      units = 'objectBoundingBox';
+    }
+    if (!spread) {
+      spread = 'pad';
+    }
+
     var x1 = parseFloat(node.getAttribute('x1') || 0);
     var y1 = parseFloat(node.getAttribute('y1') || 0);
     var x2 = parseFloat(node.getAttribute('x2') || 0);
@@ -1181,6 +1191,13 @@ var read = {
 
     var ox = (x2 + x1) / 2;
     var oy = (y2 + y1) / 2;
+
+    if (/userSpaceOnUse/i.test(units)) {
+      x1 -= ox;
+      y1 -= oy;
+      x2 -= ox;
+      y2 -= oy;
+    }
 
     var stops = [];
     for (var i = 0; i < node.children.length; i++) {
@@ -1214,8 +1231,10 @@ var read = {
 
     }
 
-    var gradient = new LinearGradient(x1 - ox, y1 - oy, x2 - ox,
-      y2 - oy, stops);
+    var gradient = new LinearGradient(x1, y1, x2, y2, stops);
+
+    gradient.spread = spread;
+    gradient.units = units;
 
     applySvgAttributes.call(this, node, gradient, parentStyles);
 
@@ -1224,6 +1243,16 @@ var read = {
   },
 
   radialgradient: function(node, parentStyles) {
+
+    var units = node.getAttribute('gradientUnits');
+    var spread = node.getAttribute('spreadMethod');
+
+    if (!units) {
+      units = 'objectBoundingBox';
+    }
+    if (!spread) {
+      spread = 'pad';
+    }
 
     var cx = parseFloat(node.getAttribute('cx')) || 0;
     var cy = parseFloat(node.getAttribute('cy')) || 0;
@@ -1243,6 +1272,13 @@ var read = {
     var ox = Math.abs(cx + fx) / 2;
     var oy = Math.abs(cy + fy) / 2;
 
+    if (/userSpaceOnUse/i.test(units)) {
+      cx -= ox;
+      cy -= oy;
+      fx -= ox;
+      fy -= oy;
+    }
+
     var stops = [];
     for (var i = 0; i < node.children.length; i++) {
 
@@ -1275,8 +1311,8 @@ var read = {
 
     }
 
-    var gradient = new RadialGradient(cx - ox, cy - oy, r,
-      stops, fx - ox, fy - oy);
+    var gradient = new RadialGradient(cx, cy, r,
+      stops, fx, fy);
 
     applySvgAttributes.call(this, node, gradient, parentStyles);
 

--- a/wiki/change-log/README.md
+++ b/wiki/change-log/README.md
@@ -9,6 +9,13 @@ lang: en-US
 
 ## Nightly
 
++ Improved SVG gradient interpretation
++ `Two.interpret` can properly unwrap CSS `url()` commands
++ Added `Two.Gradient.units` and respected in all renderers
++ Default units space for `Two.Gradient` is `objectBoundingBox`
++ Removed destructive attribute assignments in `Two.interpret`
++ Interpreted gradients are reused as `<defs />`
+
 ## Nov 24, 2021 v0.7.12
 
 <h3 class="visible">Nov 24, 2021</h3><version-link v="v0.7.12" />


### PR DESCRIPTION
This PR adds:

+ `Two.Gradient.units` for different spatial units
+ Defaults to `objectBoundingBox`, a normalized the space for gradient rendering
+ `Two.interpret` improvements for gradients and CSS `url()` commands