### PR TITLE
Update README.md

### DIFF
--- a/src/shapes/ellipse.js
+++ b/src/shapes/ellipse.js
@@ -94,13 +94,13 @@ _.extend(Ellipse.prototype, Path.prototype, {
   _flagHeight: false,
 
   /**
-   * @name Two.Polygon#_width
+   * @name Two.Ellipse#_width
    * @private
    * @see {@link Two.Ellipse#width}
    */
   _width: 0,
   /**
-   * @name Two.Polygon#_height
+   * @name Two.Ellipse#_height
    * @private
    * @see {@link Two.Ellipse#height}
    */
@@ -177,8 +177,8 @@ _.extend(Ellipse.prototype, Path.prototype, {
    * @name Two.Ellipse#clone
    * @function
    * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-   * @returns {Two.Polygon}
-   * @description Create a new instance of {@link Two.Polygon} with the same properties of the current path.
+   * @returns {Two.Ellipse}
+   * @description Create a new instance of {@link Two.Ellipse} with the same properties of the current path.
    */
   clone: function(parent) {
 

--- a/wiki/docs/shapes/ellipse/README.md
+++ b/wiki/docs/shapes/ellipse/README.md
@@ -260,7 +260,7 @@ __Returns__: Two.Polygon
 
 <div class="description">
 
-Create a new instance of [Two.Polygon](/docs/shapes/polygon/) with the same properties of the current path.
+Create a new instance of [Two.Ellipse](/docs/shapes/ellipse/) with the same properties of the current path.
 
 </div>
 


### PR DESCRIPTION
I think that 

Create a new instance of [Two.Polygon](/docs/shapes/polygon/) with the same properties of the current path.

should be 

Create a new instance of [Two.Ellipse](/docs/shapes/ellipse/) with the same properties of the current path.