### PR TITLE
respect snake case for datasets

### DIFF
--- a/src/renderers/svg.js
+++ b/src/renderers/svg.js
@@ -371,9 +371,7 @@ var svg = {
       }
 
       if (this.dataset) {
-        for (var key in this.dataset) {
-          this._renderer.elem.setAttribute('data-' + key, this.dataset[key]);
-        }
+        Object.assign(this._renderer.elem.dataset, this.dataset)
       }
 
       return this.flagReset();


### PR DESCRIPTION
Hey @jonobr1 :)
 
I've come up with a small fix for the data attributes that have 2+ hyphens. I didn't take into account that js `.dataset` property had data attributes in camelCase, which made it rendered like this:
![Screenshot from 2021-12-22 14-09-29](https://user-images.githubusercontent.com/20026712/147091309-e7313c58-99cf-4976-8590-16ca29e7e3de.png)

Found the proper way to copy dataset from an element to another here https://stackoverflow.com/a/20074111 
Having this, data attributes are rendered accurately:
![Screenshot from 2021-12-22 14-09-52](https://user-images.githubusercontent.com/20026712/147091942-6e1faaa4-91b5-415c-84b5-8e805ad1c68b.png)

