### PR TITLE
moved flagging classname to the common applySvgAttributes method

### DIFF
--- a/src/utils/interpret-svg.js
+++ b/src/utils/interpret-svg.js
@@ -454,6 +454,7 @@ var applySvgAttributes = function(node, elem, parentStyles) {
       case 'class':
       case 'className':
         elem.classList = value.split(' ');
+        elem._flagClassName = true;
         break;
       case 'x':
       case 'y':
@@ -662,8 +663,6 @@ var read = {
         }
       }
     }
-
-    if (group.classList.length > 0) group._flagClassName = true;
 
     return group;
 


### PR DESCRIPTION
Hello again, @jonobr1 !

It's me, G̶o̶n̶z̶a̶l̶o̶! I mean the data-attributes guy :^)

Recently I spent a few hours figuring out how to add custom classes to Group (`<g>`) elements in Inkscape, but failed miserably. I could only add it to `<Path>` or `<Ellipse>` ones... Unfortunately during the interpretation, two.js didn't transfer the custom class I had added to the interpreted element, so I jumped into the code, added the good ol' `if (path.classList.length > 0) path._flagClassName = true` and the class appeared in the interpreted element perfectly. 

Not to duplicate the code, I moved flagging to the `applySvgAttributes` function, which is common among the tags, and now the class attribute is rendered both in `<g>` and `<Path>` (`.md-desk`; `.occupancy-status`):
![Screenshot from 2021-12-28 00-53-49](https://user-images.githubusercontent.com/20026712/147512747-a6c923a1-bda3-41a2-8067-095aa615d142.png)

Having this, an element related to svg ( `<g>`, `<Path>`, etc) will copy the class list of the interpreted one. I think it's super-handy.