### PR TITLE
Add radius property to polygon class

### DIFF
--- a/src/shapes/polygon.js
+++ b/src/shapes/polygon.js
@@ -37,6 +37,12 @@ export class Polygon extends Path {
   _flagSides = false;
 
   /**
+   * @name Two.Polygon#_radius
+   * @private
+   * @see {@link Two.Polygon#radius}
+   */
+  _radius = 0;
+  /**
    * @name Two.Polygon#_width
    * @private
    * @see {@link Two.Polygon#width}
@@ -69,20 +75,22 @@ export class Polygon extends Path {
     this.automatic = false;
 
     /**
+     * @name Two.Polygon#radius
+     * @property {Number} - The radius value of the polygon.
+     */
+    if (typeof r === 'number') {
+      this.radius = r;
+    }
+
+    /**
      * @name Two.Polygon#width
      * @property {Number} - The size of the width of the polygon.
      */
-    if (typeof r === 'number') {
-      this.width = r * 2;
-    }
 
     /**
      * @name Two.Polygon#height
      * @property {Number} - The size of the height of the polygon.
      */
-    if (typeof r === 'number') {
-      this.height = r * 2;
-    }
 
     /**
      * @name Two.Polygon#sides
@@ -178,13 +186,15 @@ export class Polygon extends Path {
    */
   clone(parent) {
 
-    const clone = new Polygon(0, 0, this.radius, this.sides);
+    const clone = new Polygon(0, 0, 0, this.sides);
 
     clone.translation.copy(this.translation);
     clone.rotation = this.rotation;
     clone.scale = this.scale;
     clone.skewX = this.skewX;
     clone.skewY = this.skewY;
+    clone.width = this.width;
+    clone.height = this.height;
 
     if (this.matrix.manual) {
       clone.matrix.copy(this.matrix);
@@ -225,6 +235,17 @@ export class Polygon extends Path {
 }
 
 const proto = {
+  radius: {
+    enumerable: true,
+    get: function() {
+      return this._radius;
+    },
+    set: function(v) {
+      this._radius = v;
+      this.width = v * 2;
+      this.height = v * 2;
+    }
+  },
   width: {
     enumerable: true,
     get: function() {
@@ -233,6 +254,7 @@ const proto = {
     set: function(v) {
       this._width = v;
       this._flagWidth = true;
+      this._radius = Math.max(this.width, this.height) / 2;
     }
   },
   height: {
@@ -243,6 +265,7 @@ const proto = {
     set: function(v) {
       this._height = v;
       this._flagHeight = true;
+      this._radius = Math.max(this.width, this.height) / 2;
     }
   },
   sides: {

--- a/wiki/docs/shapes/polygon/README.md
+++ b/wiki/docs/shapes/polygon/README.md
@@ -71,8 +71,55 @@ A list of properties that are on every [Two.Polygon](/docs/shapes/polygon/).
 
 <div class="meta">
 
-  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L106">
-    polygon.js:106
+  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L114">
+    polygon.js:114
+  </a>
+
+</div>
+
+
+
+
+</div>
+
+
+
+<div class="instance member ">
+
+## radius
+
+<h2 class="longname" aria-hidden="true"><a href="#radius"><span class="prefix">Two.Polygon.</span><span class="shortname">radius</span></a></h2>
+
+
+
+
+
+
+
+
+
+
+<div class="properties">
+
+
+The radius value of the polygon.
+
+
+</div>
+
+
+
+
+
+
+
+
+
+
+<div class="meta">
+
+  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L77">
+    polygon.js:77
   </a>
 
 </div>
@@ -118,8 +165,8 @@ The size of the width of the polygon.
 
 <div class="meta">
 
-  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L71">
-    polygon.js:71
+  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L85">
+    polygon.js:85
   </a>
 
 </div>
@@ -165,8 +212,8 @@ The size of the height of the polygon.
 
 <div class="meta">
 
-  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L79">
-    polygon.js:79
+  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L90">
+    polygon.js:90
   </a>
 
 </div>
@@ -212,8 +259,8 @@ The amount of sides the polyogn has.
 
 <div class="meta">
 
-  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L87">
-    polygon.js:87
+  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L95">
+    polygon.js:95
   </a>
 
 </div>
@@ -272,8 +319,8 @@ Create a new instance of [Two.Polygon](/docs/shapes/polygon/) with the same prop
 
 <div class="meta">
 
-  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L172">
-    polygon.js:172
+  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L180">
+    polygon.js:180
   </a>
 
 </div>
@@ -325,8 +372,8 @@ Return a JSON compatible plain object that represents the path.
 
 <div class="meta">
 
-  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L206">
-    polygon.js:206
+  <a class="lineno" target="_blank" rel="noopener noreferrer" href="https://github.com/jonobr1/two.js/blob/main/src/shapes/polygon.js#L216">
+    polygon.js:216
   </a>
 
 </div>


### PR DESCRIPTION
[These](https://github.com/jonobr1/two.js/blob/a4449a205c57697314fff54f01b0ef7cb0765541/src/shapes/polygon.js#L85-L99) assignments are now redundant, but I didn't want to delete them because I imagine the comments above them are used to generate the documentation.

I've included a correction regarding the cloning behavior too, let me know if you want that as a separate pull request.

In my previous pull request, I included the documentation changes, should I do the same for this one?