### PR TITLE
Fix Two.Polygon

### DIFF
--- a/src/shapes/polygon.js
+++ b/src/shapes/polygon.js
@@ -102,10 +102,10 @@ export class Polygon extends Path {
 
     this._update();
 
-    if (typeof ox === 'number') {
+    if (typeof x === 'number') {
       this.translation.x = x;
     }
-    if (typeof oy === 'number') {
+    if (typeof y === 'number') {
       this.translation.y = y;
     }
 


### PR DESCRIPTION
Creating a polygon with `Two.makePolygon` does not set the `x` and `y` coordinates of the shape. This fix addresses this issue.

### Steps to reproduce.

```js
const params = {
  width: 300,
  height: 300,
}

const two = new Two(params).appendTo(document.getElementById('container'))

const polygon = two.makePolygon(150, 150, 100, 12)
two.update()
```

### Actual Result
![image](https://user-images.githubusercontent.com/70096033/167787645-1b4d55eb-4e78-4a20-9fb2-60da37d54bbf.png)
### Expected Result
![image](https://user-images.githubusercontent.com/70096033/167788085-eb125190-c34b-4711-87a5-72f445c19b79.png)


P.S. first time contributing.