### PR TITLE
Fix Path.getPointAt prototype

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -2453,12 +2453,12 @@ declare module "two.js/src/path" {
         /**
          * @name Two.Path#getPointAt
          * @function
-         * @param {Boolean} t - Percentage value describing where on the {@link Two.Path} to estimate and assign coordinate values.
+         * @param {Number} t - Percentage value describing where on the {@link Two.Path} to estimate and assign coordinate values.
          * @param {Vector} [obj] - Object to apply calculated x, y to. If none available returns new `Object`.
          * @returns {Object}
          * @description Given a float `t` from 0 to 1, return a point or assign a passed `obj`'s coordinates to that percentage on this {@link Two.Path}'s curve.
          */
-        getPointAt(t: boolean, obj: any): any;
+        getPointAt(t: number, obj: any): any;
         /**
          * @name Two.Path#plot
          * @function


### PR DESCRIPTION
The prototype of Path.getPointAt incorrectly took a boolean instead of a number as its first parameter