### PR TITLE
Added remove implementation of Two.Group signature

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1435,6 +1435,26 @@ declare module "two.js/src/group" {
         add(objects: TwoElement): Group;
         add(...args: TwoElement[]): Group;
         /**
+         * @name Two.Group#remove
+         * @function
+         * @description Remove self from the scene / parent.
+         */
+        remove(): Shape;
+        /**
+         * @name Two.Group#remove
+         * @function
+         * @param {Shape[]} objects - An array of objects to be removed. Can also be supplied as individual arguments.
+         * @description Remove objects from the group.
+         */
+        remove(objects: Array<Shape>): Shape;
+        /**
+         * @name Two.Group#remove
+         * @function
+         * @params {...Shape} [args] - Alternatively pass shapes as each argument
+         * @description Remove objects from the group.
+         */
+        remove(...args: Shape[]): Shape;
+        /**
          * @name Two.Group#getBoundingClientRect
          * @function
          * @param {Boolean} [shallow=false] - Describes whether to calculate off local matrix or world matrix.


### PR DESCRIPTION
If I am not mistaken this should be the signature of remove. It can remove itself from the parent. It can remove children passed as an array, and also it can extract those children from arguments. This implementation overrides Shape.remove, I Think it should override signatures as well.