### PR TITLE
clientToSurface & surfaceToClient signatures

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -4486,8 +4486,11 @@ declare module "two.js/extras/jsm/zui" {
         surfaces: any[];
         add(surface: any): ZUI;
         addLimits(min: number, max: number, type?: number): ZUI;
-        clientToSurface(x: any, y: any): any;
-        surfaceToClient(v: any): any;
+        clientToSurface(): Matrix;
+        clientToSurface(x: number): Matrix;
+        clientToSurface(x: number, y: number): { x: number, y: number, z: number };
+        surfaceToClient(v: {}): Matrix;
+        surfaceToClient(v: { x?: number, y?: number, z?: number }): { x: number, y: number, z: number };
         zoomBy(byF: any, clientX: any, clientY: any): ZUI;
         zoomSet(zoom: any, clientX: any, clientY: any): ZUI;
         zoom: number;


### PR DESCRIPTION
Added clientToSurface and surfaceToClient signatures.

surfaceToClient has x, y and z optional, but if none of them is provided, it strangely returns a Matrix, which I did not understand, but did not try to understand as well 😁. Line with an empty object parameter on top of real signature is for intellisense of the ReturnType.

same thing is also true for clientToSurface with missing arguments.