### PR TITLE
docs: edit spelling on gradient documentation

### DIFF
--- a/src/two.js
+++ b/src/two.js
@@ -899,9 +899,9 @@ export default class Two {
    * @param {Number} y1
    * @param {Number} x2
    * @param {Number} y2
-   * @param {...Two.Stop} args - Any number of color stops sometimes reffered to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
+   * @param {...Two.Stop} args - Any number of color stops sometimes referred to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
    * @returns {Two.LinearGradient}
-   * @description Creates a Two.js linear gradient and ads it to the scene. In the case of an effect it's added to an invisible "definitions" group.
+   * @description Creates a Two.js linear gradient and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
    */
   makeLinearGradient(x1, y1, x2, y2 /* stops */) {
 
@@ -920,9 +920,9 @@ export default class Two {
    * @param {Number} x1
    * @param {Number} y1
    * @param {Number} radius
-   * @param {...Two.Stop} args - Any number of color stops sometimes reffered to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
+   * @param {...Two.Stop} args - Any number of color stops sometimes referred to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
    * @returns {Two.RadialGradient}
-   * @description Creates a Two.js linear-gradient object and ads it to the scene. In the case of an effect it's added to an invisible "definitions" group.
+   * @description Creates a Two.js linear-gradient object and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
    */
   makeRadialGradient(x1, y1, radius /* stops */) {
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,4 @@
-declare module "two.js/src/utils/path-commands" {
+declare module "src/utils/path-commands" {
     export namespace Commands {
         const move: string;
         const line: string;
@@ -7,28 +7,27 @@ declare module "two.js/src/utils/path-commands" {
         const close: string;
     }
 }
-declare module "two.js/src/utils/root" {
+declare module "src/utils/root" {
     export let root: any;
 }
-declare module "two.js/src/utils/math" {
+declare module "src/utils/math" {
     /**
      * @name Two.Utils.decomposeMatrix
      * @function
-     * @param {Matrix} matrix - The matrix to decompose.
+     * @param {Two.Matrix} matrix - The matrix to decompose.
      * @returns {Object} An object containing relevant skew values.
      * @description Decompose a 2D 3x3 Matrix to find the skew.
      */
-    export function decomposeMatrix(matrix: Matrix): any;
-    export function decomposeMatrix(a: number, b: number, c: number, d: number, e: number, f: number): any;
+    export function decomposeMatrix(matrix: Two.Matrix, b: any, c: any, d: any, e: any, f: any, ...args: any[]): any;
     /**
      * @name Two.Utils.getComputedMatrix
      * @function
-     * @param {Shape} object - The Two.js object that has a matrix property to calculate from.
-     * @param {Matrix} [matrix] - The matrix to apply calculated transformations to if available.
-     * @returns {Matrix} The computed matrix of a nested object. If no `matrix` was passed in arguments then a `new Two.Matrix` is returned.
+     * @param {Two.Shape} object - The Two.js object that has a matrix property to calculate from.
+     * @param {Two.Matrix} [matrix] - The matrix to apply calculated transformations to if available.
+     * @returns {Two.Matrix} The computed matrix of a nested object. If no `matrix` was passed in arguments then a `new Two.Matrix` is returned.
      * @description Method to get the world space transformation of a given object in a Two.js scene.
      */
-    export function getComputedMatrix(object: Shape, matrix?: Matrix): Matrix;
+    export function getComputedMatrix(object: Two.Shape, matrix?: Two.Matrix): Two.Matrix;
     export function getPoT(value: any): number;
     export function setMatrix(matrix: any): void;
     /**
@@ -62,10 +61,8 @@ declare module "two.js/src/utils/math" {
     export function toFixed(v: number): number;
     export const TWO_PI: number;
     export const HALF_PI: number;
-    import { Matrix } from "two.js/src/matrix";
-    import { Shape } from "two.js/src/shape";
 }
-declare module "two.js/src/events" {
+declare module "src/events" {
     /**
      * @name Two.Events
      * @class
@@ -144,79 +141,102 @@ declare module "two.js/src/events" {
         ignore(obj: any, name: any, handler: any): Events;
     }
 }
-declare module "two.js/src/vector" {
+declare module "src/vector" {
     /**
      * @name Two.Vector
      * @class
-
+     * @extends Two.Events
      * @param {Number} [x=0] - Any number to represent the horizontal x-component of the vector.
      * @param {Number} [y=0] - Any number to represent the vertical y-component of the vector.
      * @description A class to store x / y component vector data. In addition to storing data `Two.Vector` has suped up methods for commonplace mathematical operations.
      */
-    export class Vector extends Events {
+    export class Vector {
         /**
          * @name Two.Vector.zero
          * @readonly
-         * @property {Vector} - Handy reference to a vector with component values 0, 0 at all times.
+         * @property {Two.Vector} - Handy reference to a vector with component values 0, 0 at all times.
          */
         static readonly zero: Vector;
         /**
+         * @name Two.Vector.left
+         * @readonly
+         * @property {Two.Vector} - Handy reference to a vector with component values -1, 0 at all times.
+         */
+        static readonly left: Vector;
+        /**
+         * @name Two.Vector.right
+         * @readonly
+         * @property {Two.Vector} - Handy reference to a vector with component values 1, 0 at all times.
+         */
+        static readonly right: Vector;
+        /**
+         * @name Two.Vector.up
+         * @readonly
+         * @property {Two.Vector} - Handy reference to a vector with component values 0, -1 at all times.
+         */
+        static readonly up: Vector;
+        /**
+         * @name Two.Vector.down
+         * @readonly
+         * @property {Two.Vector} - Handy reference to a vector with component values 0, 1 at all times.
+         */
+        static readonly down: Vector;
+        /**
          * @name Two.Vector.add
          * @function
-         * @param {Vector} v1
-         * @param {Vector} v2
-         * @returns {Vector}
+         * @param {Two.Vector} v1
+         * @param {Two.Vector} v2
+         * @returns {Two.Vector}
          * @description Add two vectors together.
          */
-        static add(v1: Vector, v2: Vector): Vector;
+        static add(v1: Two.Vector, v2: Two.Vector): Two.Vector;
         /**
          * @name Two.Vector.sub
          * @function
-         * @param {Vector} v1
-         * @param {Vector} v2
-         * @returns {Vector}
+         * @param {Two.Vector} v1
+         * @param {Two.Vector} v2
+         * @returns {Two.Vector}
          * @description Subtract two vectors: `v2` from `v1`.
          */
-        static sub(v1: Vector, v2: Vector): Vector;
+        static sub(v1: Two.Vector, v2: Two.Vector): Two.Vector;
         /**
          * @name Two.Vector.subtract
          * @function
          * @description Alias for {@link Two.Vector.sub}.
          */
-        static subtract(v1: Vector, v2: Vector): Vector;
+        static subtract(v1: any, v2: any): Two.Vector;
         /**
          * @name Two.Vector.ratioBetween
          * @function
-         * @param {Vector} v1
-         * @param {Vector} v2
+         * @param {Two.Vector} v1
+         * @param {Two.Vector} v2
          * @returns {Number} The ratio betwen two points `v1` and `v2`.
          */
-        static ratioBetween(v1: Vector, v2: Vector): number;
+        static ratioBetween(v1: Two.Vector, v2: Two.Vector): number;
         /**
          * @name Two.Vector.angleBetween
          * @function
-         * @param {Vector} v1
-         * @param {Vector} v2
+         * @param {Two.Vector} v1
+         * @param {Two.Vector} v2
          * @returns {Number} The angle between points `v1` and `v2`.
          */
-        static angleBetween(v1: Vector, v2: Vector): number;
-        static angleBetween(x1: number, y1: number, x2: number, y2: number): number;
+        static angleBetween(v1: Two.Vector, v2: Two.Vector, ...args: any[]): number;
         /**
          * @name Two.Vector.distanceBetween
          * @function
-         * @param {Vector} v1
-         * @param {Vector} v2
+         * @param {Two.Vector} v1
+         * @param {Two.Vector} v2
          * @returns {Number} The distance between points `v1` and `v2`. Distance is always positive.
          */
-        static distanceBetween(v1: Vector, v2: Vector): number;
+        static distanceBetween(v1: Two.Vector, v2: Two.Vector): number;
         /**
          * @name Two.Vector.distanceBetweenSquared
          * @function
-         * @param {Vector} v1
-         * @param {Vector} v2
+         * @param {Two.Vector} v1
+         * @param {Two.Vector} v2
          * @returns {Number} The squared distance between points `v1` and `v2`.
          */
-        static distanceBetweenSquared(v1: Vector, v2: Vector): number;
+        static distanceBetweenSquared(v1: Two.Vector, v2: Two.Vector): number;
         constructor(x?: number, y?: number);
         /**
          * @name Two.Vector#_x
@@ -240,14 +260,14 @@ declare module "two.js/src/vector" {
          * @type {Number}
          */
         y: number;
-        set(x: number, y: number): Vector;
+        set(x: any, y: any): Vector;
         /**
          * @name Two.Vector#copy
          * @function
-         * @param {Vector} v
+         * @param {Two.Vector} v
          * @description Copy the x / y components of another object `v`.
          */
-        copy(v: Vector): Vector;
+        copy(v: Two.Vector): Vector;
         /**
          * @name Two.Vector#clear
          * @function
@@ -263,11 +283,10 @@ declare module "two.js/src/vector" {
         /**
          * @name Two.Vector#add
          * @function
-         * @param {Vector} v
+         * @param {Two.Vector} v
          * @description Add an object with x / y component values to the instance.
          * @overloaded
          */
-        add(v: Vector): Vector;
         /**
          * @name Two.Vector#add
          * @function
@@ -275,7 +294,6 @@ declare module "two.js/src/vector" {
          * @description Add the **same** number to both x / y component values of the instance.
          * @overloaded
          */
-        add(v: number): Vector;
         /**
          * @name Two.Vector#add
          * @function
@@ -284,23 +302,20 @@ declare module "two.js/src/vector" {
          * @description Add `x` / `y` values to their respective component value on the instance.
          * @overloaded
          */
-        add(x: number, y: number): Vector;
+        add(x: number, y: number, ...args: any[]): Vector;
         /**
          * @name Two.Vector#addSelf
          * @function
          * @description Alias for {@link Two.Vector.add}.
          */
-        addSelf(x: number, y: number): Vector;
-        addSelf(v: Vector): Vector;
-        addSelf(v: number): Vector;
+        addSelf(v: any, ...args: any[]): any;
         /**
          * @name Two.Vector#sub
          * @function
-         * @param {Vector} v
+         * @param {Two.Vector} v
          * @description Subtract an object with x / y component values to the instance.
          * @overloaded
          */
-        sub(v: Vector): Vector;
         /**
          * @name Two.Vector#sub
          * @function
@@ -308,7 +323,6 @@ declare module "two.js/src/vector" {
          * @description Subtract the **same** number to both x / y component values of the instance.
          * @overloaded
          */
-        sub(v: number): Vector;
         /**
          * @name Two.Vector#sub
          * @function
@@ -317,39 +331,32 @@ declare module "two.js/src/vector" {
          * @description Subtract `x` / `y` values to their respective component value on the instance.
          * @overloaded
          */
-        sub(x: number, y: number): Vector;
+        sub(x: number, y: number, ...args: any[]): Vector;
         /**
          * @name Two.Vector#subtract
          * @function
          * @description Alias for {@link Two.Vector.sub}.
          */
-        subtract(x: number, y: number): Vector;
-        subtract(v: number): Vector;
-        subtract(v: Vector): Vector;
+        subtract(...args: any[]): any;
         /**
          * @name Two.Vector#subSelf
          * @function
          * @description Alias for {@link Two.Vector.sub}.
          */
-        subSelf(x: number, y: number): Vector;
-        subSelf(v: number): Vector;
-        subSelf(v: Vector): Vector;
+        subSelf(v: any, ...args: any[]): any;
         /**
          * @name Two.Vector#subtractSelf
          * @function
          * @description Alias for {@link Two.Vector.sub}.
          */
-        subtractSelft(x: number, y: number): Vector;
-        subtractSelft(v: number): Vector;
-        subtractSelft(v: Vector): Vector;
+        subtractSelf(v: any, ...args: any[]): any;
         /**
          * @name Two.Vector#multiply
          * @function
-         * @param {Vector} v
+         * @param {Two.Vector} v
          * @description Multiply an object with x / y component values to the instance.
          * @overloaded
          */
-        multiply(v: number): Vector;
         /**
          * @name Two.Vector#multiply
          * @function
@@ -357,7 +364,6 @@ declare module "two.js/src/vector" {
          * @description Multiply the **same** number to both x / y component values of the instance.
          * @overloaded
          */
-        multiply(v: Vector): Vector;
         /**
          * @name Two.Vector#multiply
          * @function
@@ -366,7 +372,7 @@ declare module "two.js/src/vector" {
          * @description Multiply `x` / `y` values to their respective component value on the instance.
          * @overloaded
          */
-        multiply(x: number, y: number): Vector;
+        multiply(x: number, y: number, ...args: any[]): Vector;
         /**
          * @name Two.Vector#multiplySelf
          * @function
@@ -383,11 +389,10 @@ declare module "two.js/src/vector" {
         /**
          * @name Two.Vector#divide
          * @function
-         * @param {Vector} v
+         * @param {Two.Vector} v
          * @description Divide an object with x / y component values to the instance.
          * @overloaded
          */
-        divide(v: Vector): Vector;
         /**
          * @name Two.Vector#divide
          * @function
@@ -395,7 +400,6 @@ declare module "two.js/src/vector" {
          * @description Divide the **same** number to both x / y component values of the instance.
          * @overloaded
          */
-        divide(v: number): Vector;
         /**
          * @name Two.Vector#divide
          * @function
@@ -404,15 +408,13 @@ declare module "two.js/src/vector" {
          * @description Divide `x` / `y` values to their respective component value on the instance.
          * @overloaded
          */
-        divide(x: number, y: number): Vector;
+        divide(x: number, y: number, ...args: any[]): Vector;
         /**
          * @name Two.Vector#divideSelf
          * @function
          * @description Alias for {@link Two.Vector.divide}.
          */
-        divideSelf(x: number, y: number): Vector;
-        divideSelf(v: number): Vector;
-        divideSelf(v: Vector): Vector;
+        divideSelf(v: any, ...args: any[]): any;
         /**
          * @name Two.Vector#divideScalar
          * @function
@@ -427,12 +429,12 @@ declare module "two.js/src/vector" {
          */
         negate(): Vector;
         /**
-         * @name Two.Vector#negate
+         * @name Two.Vector#dot
          * @function
          * @returns {Number}
          * @description Get the [dot product](https://en.wikipedia.org/wiki/Dot_product) of the vector.
          */
-        dot(v: Vector): number;
+        dot(v: any): number;
         /**
          * @name Two.Vector#length
          * @function
@@ -466,7 +468,7 @@ declare module "two.js/src/vector" {
          * @returns {Number}
          * @description Get the distance between two vectors to the power of two. Widely used as less expensive than {@link Two.Vector#distanceTo} because it isn't square-rooting any numbers.
          */
-        distanceToSquared(v: Vector): number;
+        distanceToSquared(v: any): number;
         /**
          * @name Two.Vector#setLength
          * @function
@@ -477,21 +479,21 @@ declare module "two.js/src/vector" {
         /**
          * @name Two.Vector#equals
          * @function
-         * @param {Vector} v - The vector to compare against.
+         * @param {Two.Vector} v - The vector to compare against.
          * @param {Number} [eps=0.0001] - An options epsilon for precision.
          * @returns {Boolean}
          * @description Qualify if one vector roughly equal another. With a margin of error defined by epsilon.
          */
-        equals(v: Vector, eps?: number): boolean;
+        equals(v: Two.Vector, eps?: number): boolean;
         /**
          * @name Two.Vector#lerp
          * @function
-         * @param {Vector} v - The destination vector to step towards.
+         * @param {Two.Vector} v - The destination vector to step towards.
          * @param {Number} t - The zero to one value of how close the current vector gets to the destination vector.
          * @description Linear interpolate one vector to another by an amount `t` defined as a zero to one number.
          * @see [Matt DesLauriers](https://twitter.com/mattdesl/status/1031305279227478016) has a good thread about this.
          */
-        lerp(v: Vector, t: number): Vector;
+        lerp(v: Two.Vector, t: number): Vector;
         /**
          * @name Two.Vector#isZero
          * @function
@@ -500,6 +502,13 @@ declare module "two.js/src/vector" {
          * @description Check to see if vector is roughly zero, based on the `epsilon` precision value.
          */
         isZero(eps?: number): boolean;
+        /**
+         * @name Two.Vector#toString
+         * @function
+         * @returns {String}
+         * @description Return a comma-separated string of x, y value. Great for storing in a database.
+         */
+        toString(): string;
         /**
          * @name Two.Vector#toObject
          * @function
@@ -515,9 +524,8 @@ declare module "two.js/src/vector" {
          */
         rotate(radians: number): Vector;
     }
-    import { Events } from "two.js/src/events";
 }
-declare module "two.js/src/anchor" {
+declare module "src/anchor" {
     /**
      * @class
      * @name Two.Anchor
@@ -528,10 +536,10 @@ declare module "two.js/src/anchor" {
      * @param {Number} [rx=0] - The x position of the right handle point.
      * @param {Number} [ry=0] - The y position of the right handle point.
      * @param {String} [command=Two.Commands.move] - The command to describe how to render. Applicable commands are {@link Two.Commands}
-
+     * @extends Two.Vector
      * @description An object that holds 3 {@link Two.Vector}s, the anchor point and its corresponding handles: `left` and `right`. In order to properly describe the bezier curve about the point there is also a command property to describe what type of drawing should occur when Two.js renders the anchors.
      */
-    export class Anchor extends Vector {
+    export class Anchor {
         static makeBroadcast(scope: any): () => void;
         constructor(x?: number, y?: number, ax?: number, ay?: number, bx?: number, by?: number, command?: string);
         controls: {
@@ -547,15 +555,45 @@ declare module "two.js/src/anchor" {
         _sweepFlag: number;
         command: string;
         relative: boolean;
+        /**
+         * @name Two.Anchor#copy
+         * @function
+         * @param {Two.Anchor} v - The anchor to apply values to.
+         * @description Copy the properties of one {@link Two.Anchor} onto another.
+         */
+        copy(v: Two.Anchor): Anchor;
+        x: any;
+        y: any;
         rx: any;
         ry: any;
         xAxisRotation: any;
         largeArcFlag: any;
         sweepFlag: any;
+        /**
+         * @name Two.Anchor#clone
+         * @function
+         * @returns {Two.Anchor}
+         * @description Create a new {@link Two.Anchor}, set all its values to the current instance and return it for use.
+         */
+        clone(): Two.Anchor;
+        /**
+         * @name Two.Anchor#toObject
+         * @function
+         * @returns {Object} - An object with properties filled out to mirror {@link Two.Anchor}.
+         * @description Create a JSON compatible plain object of the current instance. Intended for use with storing values in a database.
+         */
+        toObject(): any;
+        /**
+         * @name Two.Anchor#toString
+         * @function
+         * @returns {String} - A String with comma-separated values reflecting the various values on the current instance.
+         * @description Create a string form of the current instance. Intended for use with storing values in a database. This is lighter to store than the JSON compatible {@link Two.Anchor#toObject}.
+         */
+        toString(): string;
     }
-    import { Vector } from "two.js/src/vector";
+    import { Vector } from "src/vector";
 }
-declare module "two.js/src/constants" {
+declare module "src/constants" {
     export namespace Constants {
         const nextFrameID: any;
         namespace Types {
@@ -572,7 +610,7 @@ declare module "two.js/src/constants" {
         function uniqueId(): number;
     }
 }
-declare module "two.js/src/utils/curves" {
+declare module "src/utils/curves" {
     export namespace Curve {
         const CollinearityEpsilon: number;
         const RecursionLimit: number;
@@ -695,10 +733,10 @@ declare module "two.js/src/utils/curves" {
      * @param {Boolean} [ccw=false] - Set path traversal to counter-clockwise
      */
     export function getAnchorsFromArcData(center: Vector, xAxisRotation: number, rx: number, ry: number, ts: number, td: number, ccw?: boolean): void;
-    import { Anchor } from "two.js/src/anchor";
-    import { Vector } from "two.js/src/vector";
+    import { Anchor } from "src/anchor";
+    import { Vector } from "src/vector";
 }
-declare module "two.js/src/utils/device-pixel-ratio" {
+declare module "src/utils/device-pixel-ratio" {
     /**
      * @name Two.Utils.getRatio
      * @function
@@ -708,7 +746,7 @@ declare module "two.js/src/utils/device-pixel-ratio" {
      */
     export function getRatio(ctx: CanvasRenderingContext2D): number;
 }
-declare module "two.js/src/utils/underscore" {
+declare module "src/utils/underscore" {
     export namespace _ {
         function isNaN(obj: any): boolean;
         function isElement(obj: any): boolean;
@@ -719,14 +757,14 @@ declare module "two.js/src/utils/underscore" {
         const performance: any;
     }
 }
-declare module "two.js/src/element" {
+declare module "src/element" {
     /**
      * @name Two.Element
      * @class
-
+     * @extends Two.Events
      * @description The foundational object for the Two.js scenegraph.
      */
-    export class Element extends Events {
+    export class Element {
         /**
          * @name Two.Element#_flagId
          * @private
@@ -770,9 +808,8 @@ declare module "two.js/src/element" {
          */
         flagReset(): void;
     }
-    import { Events } from "two.js/src/events";
 }
-declare module "two.js/src/matrix" {
+declare module "src/matrix" {
     /**
      * @name Two.Matrix
      * @class
@@ -797,20 +834,19 @@ declare module "two.js/src/matrix" {
         /**
          * @name Two.Matrix.Multiply
          * @function
-         * @param {Matrix} A
-         * @param {Matrix} B
-         * @param {Matrix} [C] - An optional matrix to apply the multiplication to.
-         * @returns {Matrix} - If an optional `C` matrix isn't passed then a new one is created and returned.
+         * @param {Two.Matrix} A
+         * @param {Two.Matrix} B
+         * @param {Two.Matrix} [C] - An optional matrix to apply the multiplication to.
+         * @returns {Two.Matrix} - If an optional `C` matrix isn't passed then a new one is created and returned.
          * @description Multiply two matrices together and return the result.
          */
-        static Multiply(A: Matrix, B: Matrix, C?: Matrix): Matrix;
-        constructor(elements: number[]);
-        constructor(a?: number, b?: number, c?: number, d?: number, e?: number, f?: number);
+        static Multiply(A: Two.Matrix, B: Two.Matrix, C?: Two.Matrix): Two.Matrix;
+        constructor(a: any, b: any, c: any, d: any, e: any, f: any, ...args: any[]);
         /**
          * @name Two.Matrix#elements
          * @property {Number[]} - The underlying data stored as an array.
          */
-        elements: number[];
+        elements: any;
         /**
          * @name Two.Matrix#manual
          * @property {Boolean} - Determines whether Two.js automatically calculates the values for the matrix or if the developer intends to manage the matrix.
@@ -885,10 +921,10 @@ declare module "two.js/src/matrix" {
         /**
          * @name Two.Matrix#inverse
          * @function
-         * @param {Matrix} [out] - The optional matrix to apply the inversion to.
+         * @param {Two.Matrix} [out] - The optional matrix to apply the inversion to.
          * @description Return an inverted version of the matrix. If no optional one is passed a new matrix is created and returned.
          */
-        inverse(out?: Matrix): any;
+        inverse(out?: Two.Matrix): any;
         /**
          * @name Two.Matrix#scale
          * @function
@@ -972,16 +1008,16 @@ declare module "two.js/src/matrix" {
          */
         clone(): any;
     }
-    import { Events } from "two.js/src/events";
+    import { Events } from "src/events";
 }
-declare module "two.js/src/shape" {
+declare module "src/shape" {
     /**
      * @name Two.Shape
      * @class
-
+     * @extends Two.Element
      * @description The foundational transformation object for the Two.js scenegraph.
      */
-    export class Shape extends TwoElement {
+    export class Shape {
         /**
          * @name Two.Shape#_flagMatrix
          * @private
@@ -997,19 +1033,19 @@ declare module "two.js/src/shape" {
         /**
          * @name Two.Shape#_matrix
          * @private
-         * @property {Matrix} - The matrix value of the shape's position, rotation, and scale.
+         * @property {Two.Matrix} - The matrix value of the shape's position, rotation, and scale.
          */
         private _matrix;
         /**
          * @name Two.Shape#_worldMatrix
          * @private
-         * @property {Matrix} - The matrix value of the shape's position, rotation, and scale in the scene.
+         * @property {Two.Matrix} - The matrix value of the shape's position, rotation, and scale in the scene.
          */
         private _worldMatrix;
         /**
          * @name Two.Shape#_position
          * @private
-         * @property {Vector} - The translation values as a {@link Two.Vector}.
+         * @property {Two.Vector} - The translation values as a {@link Two.Vector}.
          */
         private _position;
         /**
@@ -1021,7 +1057,7 @@ declare module "two.js/src/shape" {
         /**
          * @name Two.Shape#_scale
          * @private
-         * @property {Number|Vector} - The scale value in Number. Can be a vector for non-uniform scaling.
+         * @property {Number|Two.Vector} - The scale value in Number. Can be a vector for non-uniform scaling.
          */
         private _scale;
         /**
@@ -1045,20 +1081,20 @@ declare module "two.js/src/shape" {
         id: string;
         /**
          * @name Two.Shape#matrix
-         * @property {Matrix}
+         * @property {Two.Matrix}
          * @description The transformation matrix of the shape.
          * @nota-bene {@link Two.Shape#position}, {@link Two.Shape#rotation}, {@link Two.Shape#scale}, {@link Two.Shape#skewX}, and {@link Two.Shape#skewY} apply their values to the matrix when changed. The matrix is what is sent to the renderer to be drawn.
          */
         matrix: Matrix;
         /**
          * @name Two.Shape#worldMatrix
-         * @property {Matrix}
+         * @property {Two.Matrix}
          * @description The transformation matrix of the shape in the scene.
          */
         worldMatrix: Matrix;
         /**
          * @name Two.Shape#position
-         * @property {Vector} - The x and y value for where the shape is placed relative to its parent.
+         * @property {Two.Vector} - The x and y value for where the shape is placed relative to its parent.
          */
         position: Vector;
         /**
@@ -1071,7 +1107,7 @@ declare module "two.js/src/shape" {
          * @property {Number} - The value for how much the shape is scaled relative to its parent.
          * @nota-bene This value can be replaced with a {@link Two.Vector} to do non-uniform scaling. e.g: `shape.scale = new Two.Vector(2, 1);`
          */
-        scale: number|Vector;
+        scale: number;
         /**
          * @name Two.Shape#skewX
          * @property {Number} - The value in Number for how much the shape is skewed relative to its parent.
@@ -1086,19 +1122,20 @@ declare module "two.js/src/shape" {
         skewY: number;
         set renderer(arg: any);
         get renderer(): any;
-        set translation(arg: Vector);
+        _renderer: any;
+        set translation(arg: any);
         /**
          * @name Two.Shape#translation
          * @description Alias for {@link Two.Shape#position}.
          */
-        get translation(): Vector;
+        get translation(): any;
         /**
          * @name Two.Shape#addTo
          * @function
-         * @param {Group} group - The parent the shape adds itself to.
+         * @param {Two.Group} group - The parent the shape adds itself to.
          * @description Convenience method to add itself to the scenegraph.
          */
-        addTo(group: Group): Shape;
+        addTo(group: Two.Group): Shape;
         /**
          * @name Two.Shape#remove
          * @function
@@ -1108,11 +1145,11 @@ declare module "two.js/src/shape" {
         /**
          * @name Two.Shape#clone
          * @function
-         * @param {Group} [parent] - Optional argument to automatically add the shape to a scenegraph.
-         * @returns {Shape}
+         * @param {Two.Group} [parent] - Optional argument to automatically add the shape to a scenegraph.
+         * @returns {Two.Shape}
          * @description Create a new {@link Two.Shape} with the same values as the current shape.
          */
-        clone(parent?: Group): Shape;
+        clone(parent?: Two.Group): Two.Shape;
         /**
          * @name Two.Shape#_update
          * @function
@@ -1122,20 +1159,25 @@ declare module "two.js/src/shape" {
          * @nota-bene Try not to call this method more than once a frame.
          */
         private _update;
+        /**
+         * @name Two.Shape#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Element as TwoElement } from "two.js/src/element";
-    import { Matrix } from "two.js/src/matrix";
-    import { Vector } from "two.js/src/vector";
-    import { Group } from "two.js/src/group";
+    import { Matrix } from "src/matrix";
+    import { Vector } from "src/vector";
 }
-declare module "two.js/src/collection" {
+declare module "src/collection" {
     /**
      * @name Two.Collection
      * @class
-
+     * @extends Two.Events
      * @description An `Array` like object with additional event propagation on actions. `pop`, `shift`, and `splice` trigger `removed` events. `push`, `unshift`, and `splice` with more than 2 arguments trigger 'inserted'. Finally, `sort` and `reverse` trigger `order` events.
      */
-    export class Collection<T = any> extends Array<T> {
+    export class Collection {
         constructor(...args: any[]);
         /**
          * @private
@@ -1153,18 +1195,25 @@ declare module "two.js/src/collection" {
         trigger(...args: any[]): any;
         listen(...args: any[]): any;
         ignore(...args: any[]): any;
+        pop(...args: any[]): any;
+        shift(...args: any[]): any;
+        push(...args: any[]): any;
+        unshift(...args: any[]): any;
+        splice(...args: any[]): any;
+        sort(...args: any[]): Collection;
+        reverse(...args: any[]): Collection;
+        indexOf(...args: any[]): any;
     }
 }
-declare module "two.js/src/children" {
+declare module "src/children" {
     /**
      * @class
      * @name Two.Group.Children
-
+     * @extends Two.Collection
      * @description A children collection which is accesible both by index and by object `id`.
      */
-    export class Children extends Collection<TwoElement> {
-        constructor(children?: TwoElement[]);
-        constructor(...args: TwoElement[]);
+    export class Children {
+        constructor(children: any, ...args: any[]);
         /**
          * @name Two.Group.Children#ids
          * @property {Object} - Map of all elements in the list keyed by `id`s.
@@ -1173,47 +1222,44 @@ declare module "two.js/src/children" {
         /**
          * @function
          * @name Two.Group.Children#attach
-         * @param {Shape[]} children - The objects which extend {@link Two.Shape} to be added.
+         * @param {Two.Shape[]} children - The objects which extend {@link Two.Shape} to be added.
          * @description Adds elements to the `ids` map.
          */
-        attach(children: Shape[]): Children;
+        attach(children: Two.Shape[]): Children;
         /**
          * @function
          * @name Two.Group.Children#detach
-         * @param {Shape[]} children - The objects which extend {@link Two.Shape} to be removed.
+         * @param {Two.Shape[]} children - The objects which extend {@link Two.Shape} to be removed.
          * @description Removes elements to the `ids` map.
          */
-        detach(children: Shape[]): Children;
+        detach(children: Two.Shape[]): Children;
     }
-    import { Collection } from "two.js/src/collection";
-    import { Shape } from "two.js/src/shape";
-    import { Element as TwoElement } from "two.js/src/element";
 }
-declare module "two.js/src/group" {
+declare module "src/group" {
     /**
      * @name Two.Group
      * @class
-
-     * @param {Shape[]} [children] - A list of objects that inherit {@link Two.Shape}. For instance, the array could be a {@link Two.Path}, {@link Two.Text}, and {@link Two.RoundedRectangle}.
+     * @extends Two.Shape
+     * @param {Two.Shape[]} [children] - A list of objects that inherit {@link Two.Shape}. For instance, the array could be a {@link Two.Path}, {@link Two.Text}, and {@link Two.RoundedRectangle}.
      * @description This is the primary class for grouping objects that are then drawn in Two.js. In Illustrator this is a group, in After Effects it would be a Null Object. Whichever the case, the `Two.Group` contains a transformation matrix and commands to style its children, but it by itself doesn't render to the screen.
      * @nota-bene The {@link Two#scene} is an instance of `Two.Group`.
      */
-    export class Group extends Shape {
-        static Children: Children;
+    export class Group {
+        static Children: typeof Children;
         /**
          * @name Two.Group.InsertChildren
          * @function
-         * @param {Shape[]} children - The objects to be inserted.
+         * @param {Two.Shape[]} children - The objects to be inserted.
          * @description Cached method to let renderers know children have been added to a {@link Two.Group}.
          */
-        static InsertChildren(children: Shape[]): void;
+        static InsertChildren(children: Two.Shape[]): void;
         /**
          * @name Two.Group.RemoveChildren
          * @function
-         * @param {Shape[]} children - The objects to be removed.
+         * @param {Two.Shape[]} children - The objects to be removed.
          * @description Cached method to let renderers know children have been removed from a {@link Two.Group}.
          */
-        static RemoveChildren(children: Shape[]): void;
+        static RemoveChildren(children: Two.Shape[]): void;
         /**
          * @name Two.Group.OrderChildren
          * @function
@@ -1225,8 +1271,7 @@ declare module "two.js/src/group" {
          * @property {String[]} - A list of properties that are on every {@link Two.Group}.
          */
         static Properties: string[];
-        constructor(children?: TwoElement[]);
-        constructor(...args: TwoElement[]);
+        constructor(children: any, ...args: any[]);
         /**
          * @name Two.Group#_flagAdditions
          * @private
@@ -1282,109 +1327,117 @@ declare module "two.js/src/group" {
         private _flagMask;
         /**
          * @name Two.Group#fill
-         * @property {(String|Gradient|Texture)} - The value of what all child shapes should be filled in with.
+         * @property {(String|Two.Gradient|Two.Texture)} - The value of what all child shapes should be filled in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        fill: string|Gradient|Texture;
+        _fill: string;
         /**
          * @name Two.Group#stroke
-         * @property {(String|Gradient|Texture)} - The value of what all child shapes should be outlined in with.
+         * @property {(String|Two.Gradient|Two.Texture)} - The value of what all child shapes should be outlined in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        stroke: string|Gradient|Texture;
+        _stroke: string;
         /**
          * @name Two.Group#linewidth
          * @property {Number} - The thickness in pixels of the stroke for all child shapes.
          */
-        linewidth: number;
+        _linewidth: number;
         /**
          * @name Two.Group#opacity
          * @property {Number} - The opaqueness of all child shapes.
          * @nota-bene Becomes multiplied by the individual child's opacity property.
          */
-        opacity: number;
+        _opacity: number;
         /**
          * @name Two.Group#visible
          * @property {Boolean} - Display the path or not.
          * @nota-bene For {@link Two.CanvasRenderer} and {@link Two.WebGLRenderer} when set to false all updating is disabled improving performance dramatically with many objects in the scene.
          */
-        visible: boolean;
+        _visible: boolean;
         /**
          * @name Two.Group#cap
          * @property {String}
          * @see {@link https://www.w3.org/TR/SVG11/painting.html#StrokeLinecapProperty}
          */
-        cap: string;
+        _cap: string;
         /**
          * @name Two.Group#join
          * @property {String}
          * @see {@link https://www.w3.org/TR/SVG11/painting.html#StrokeLinejoinProperty}
          */
-        join: string;
+        _join: string;
         /**
          * @name Two.Group#miter
          * @property {String}
          * @see {@link https://www.w3.org/TR/SVG11/painting.html#StrokeMiterlimitProperty}
          */
-        miter: number;
+        _miter: number;
         /**
          * @name Two.Group#closed
          * @property {Boolean} - Determines whether a final line is drawn between the final point in the `vertices` array and the first point of all child shapes.
          */
-        closed: boolean;
+        _closed: boolean;
         /**
          * @name Two.Group#curved
          * @property {Boolean} - When the child's path is `automatic = true` this boolean determines whether the lines between the points are curved or not.
          */
-        curved: boolean;
+        _curved: boolean;
         /**
          * @name Two.Group#automatic
          * @property {Boolean} - Determines whether or not Two.js should calculate curves, lines, and commands automatically for you or to let the developer manipulate them for themselves.
          */
-        automatic: boolean;
+        _automatic: boolean;
         /**
          * @name Two.Group#beginning
          * @property {Number} - Number between zero and one to state the beginning of where the path is rendered.
          * @description {@link Two.Group#beginning} is a percentage value that represents at what percentage into all child shapes should the renderer start drawing.
          * @nota-bene This is great for animating in and out stroked paths in conjunction with {@link Two.Group#ending}.
          */
-        beginning: number;
+        _beginning: number;
         /**
          * @name Two.Group#ending
          * @property {Number} - Number between zero and one to state the ending of where the path is rendered.
          * @description {@link Two.Group#ending} is a percentage value that represents at what percentage into all child shapes should the renderer start drawing.
          * @nota-bene This is great for animating in and out stroked paths in conjunction with {@link Two.Group#beginning}.
          */
-        ending: number;
+        _ending: number;
         /**
          * @name Two.Group#length
          * @property {Number} - The sum of distances between all child lengths.
          */
-        length: number;
+        _length: number;
         /**
          * @name Two.Group#mask
-         * @property {Shape} - The Two.js object to clip from a group's rendering.
+         * @property {Two.Shape} - The Two.js object to clip from a group's rendering.
          */
-        mask: any;
+        _mask: any;
         /**
          * @name Two.Group#additions
-         * @property {Shape[]}
+         * @property {Two.Shape[]}
          * @description An automatically updated list of children that need to be appended to the renderer's scenegraph.
          */
         additions: any[];
         /**
          * @name Two.Group#subtractions
-         * @property {Shape[]}
+         * @property {Two.Shape[]}
          * @description An automatically updated list of children that need to be removed from the renderer's scenegraph.
          */
         subtractions: any[];
         /**
          * @name Two.Group#children
-         * @property {Group.Children}
+         * @property {Two.Group.Children}
          * @description A list of all the children in the scenegraph.
          * @nota-bene Ther order of this list indicates the order each element is rendered to the screen.
          */
-        children: Children;
+        children: any;
+        /**
+         * @name Two.Group#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Group}
+         * @description Create a new instance of {@link Two.Group} with the same properties of the current group.
+         */
+        clone(parent?: Two.Group): Two.Group;
         /**
          * @name Two.Group#toObject
          * @function
@@ -1408,52 +1461,37 @@ declare module "two.js/src/group" {
          * @name Two.Group#getById
          * @function
          * @description Recursively search for id. Returns the first element found.
-         * @returns {Shape} - Or `null` if nothing is found.
+         * @returns {Two.Shape} - Or `null` if nothing is found.
          */
-        getById(id: any): Shape;
+        getById(id: any): Two.Shape;
         /**
          * @name Two.Group#getByClassName
          * @function
          * @description Recursively search for classes. Returns an array of matching elements.
-         * @returns {Shape[]} - Or empty array if nothing is found.
+         * @returns {Two.Shape[]} - Or empty array if nothing is found.
          */
-        getByClassName(className: any): Shape[];
+        getByClassName(className: any): Two.Shape[];
         /**
          * @name Two.Group#getByType
          * @function
          * @description Recursively search for children of a specific type, e.g. {@link Two.Path}. Pass a reference to this type as the param. Returns an array of matching elements.
-         * @returns {Shape[]} - Empty array if nothing is found.
+         * @returns {Two.Shape[]} - Empty array if nothing is found.
          */
-        getByType(type: any): Shape[];
+        getByType(type: any): Two.Shape[];
         /**
          * @name Two.Group#add
          * @function
-         * @param {Element[]} objects - An array of objects to be added. Can also be supplied as individual arguments.
-         * @params {...Element} [args] - Alternatively pass shapes as each argument
+         * @param {Two.Shape[]|...Two.Shape} objects - An array of objects to be added. Can also be supplied as individual arguments.
          * @description Add objects to the group.
          */
-        add(objects: TwoElement): Group;
-        add(...args: TwoElement[]): Group;
+        add(objects: any, ...args: any[]): Group;
         /**
          * @name Two.Group#remove
          * @function
-         * @description Remove self from the scene / parent.
-         */
-        remove(): Shape;
-        /**
-         * @name Two.Group#remove
-         * @function
-         * @param {Shape[]} objects - An array of objects to be removed. Can also be supplied as individual arguments.
+         * @param {Two.Shape[]|...Two.Shape} [objects=self] - An array of objects to be removed. Can be also removed as individual arguments. If no arguments are passed, then it removes itself from its parent.
          * @description Remove objects from the group.
          */
-        remove(objects: Array<Shape>): Shape;
-        /**
-         * @name Two.Group#remove
-         * @function
-         * @params {...Shape} [args] - Alternatively pass shapes as each argument
-         * @description Remove objects from the group.
-         */
-        remove(...args: Shape[]): Shape;
+        remove(objects: any, ...args: any[]): Group;
         /**
          * @name Two.Group#getBoundingClientRect
          * @function
@@ -1479,34 +1517,38 @@ declare module "two.js/src/group" {
          * @function
          * @description Apply `subdivide` method to all child shapes.
          */
-        subdivide(limit?: number): Group;
+        subdivide(...args: any[]): Group;
         /**
-         * @name Two.Group#clone
+         * @name Two.Group#_update
          * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Group}
-         * @description Create a new instance of {@link Two.Group} with the same properties of the current group.
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
          */
-        clone(parent?: Group): Group;
+        private _update;
+        /**
+         * @name Two.Group#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Shape } from "two.js/src/shape";
-    import { Children } from "two.js/src/children";
-    import { Gradient } from "two.js/src/effects/gradient";
-    import { Texture } from "two.js/src/effects/texture";
-    import { Element as TwoElement } from "two.js/src/element";
+    import { Children } from "src/children";
 }
-declare module "two.js/src/renderers/canvas" {
+declare module "src/renderers/canvas" {
     /**
      * @name Two.CanvasRenderer
      * @class
-
+     * @extends Two.Events
      * @param {Object} [parameters] - This object is inherited when constructing a new instance of {@link Two}.
      * @param {Element} [parameters.domElement] - The `<canvas />` to draw to. If none given a new one will be constructed.
      * @param {Boolean} [parameters.overdraw] - Determines whether the canvas should clear the background or not. Defaults to `true`.
      * @param {Boolean} [parameters.smoothing=true] - Determines whether the canvas should antialias drawing. Set it to `false` when working with pixel art. `false` can lead to better performance, since it would use a cheaper interpolation algorithm.
      * @description This class is used by {@link Two} when constructing with `type` of `Two.Types.canvas`. It takes Two.js' scenegraph and renders it to a `<canvas />`.
      */
-    export class Renderer extends Events {
+    export class Renderer {
         /**
          * @name Two.CanvasRenderer.Utils
          * @property {Object} - A massive object filled with utility functions and properties to render Two.js objects to a `<canvas />`.
@@ -1543,12 +1585,12 @@ declare module "two.js/src/renderers/canvas" {
             };
             renderSvgArcCommand: (ctx: any, ax: any, ay: any, rx: any, ry: any, largeArcFlag: any, sweepFlag: any, xAxisRotation: any, x: any, y: any) => void;
         };
-        constructor(params?: any);
+        constructor(params: any);
         /**
          * @name Two.CanvasRenderer#domElement
          * @property {Element} - The `<canvas />` associated with the Two.js scene.
          */
-        domElement: HTMLElement;
+        domElement: any;
         /**
          * @name Two.CanvasRenderer#ctx
          * @property {Canvas2DContext} - Associated two dimensional context to render on the `<canvas />`.
@@ -1562,7 +1604,7 @@ declare module "two.js/src/renderers/canvas" {
         overdraw: any;
         /**
          * @name Two.CanvasRenderer#scene
-         * @property {Group} - The root group of the scenegraph.
+         * @property {Two.Group} - The root group of the scenegraph.
          */
         scene: Group;
         /**
@@ -1585,22 +1627,21 @@ declare module "two.js/src/renderers/canvas" {
          */
         render(): Renderer;
     }
-    import { Events } from "two.js/src/events";
-    import { Group } from "two.js/src/group";
+    import { Group } from "src/group";
 }
-declare module "two.js/src/utils/canvas-shim" {
+declare module "src/utils/canvas-shim" {
     export namespace CanvasShim {
         const Image: any;
         const isHeadless: boolean;
         function shim(canvas: any, Image?: new (width?: number, height?: number) => HTMLImageElement): any;
     }
 }
-declare module "two.js/src/utils/dom" {
+declare module "src/utils/dom" {
     export namespace dom {
         const temp: any;
     }
 }
-declare module "two.js/src/utils/error" {
+declare module "src/utils/error" {
     /**
      * @name Two.Utils.Error
      * @class
@@ -1608,9 +1649,10 @@ declare module "two.js/src/utils/error" {
      */
     export class TwoError extends Error {
         constructor(message: any);
+        message: any;
     }
 }
-declare module "two.js/src/registry" {
+declare module "src/registry" {
     /**
      * @name Two.Registry
      * @class
@@ -1651,38 +1693,37 @@ declare module "two.js/src/registry" {
         contains(id: string): boolean;
     }
 }
-declare module "two.js/src/utils/shape" {
+declare module "src/utils/shape" {
     /**
      * @private
-     * @param {Path} path - The path to analyze against.
+     * @param {Two.Path} path - The path to analyze against.
      * @param {Number} t -
      * @returns {Number}
      * @description
      */
-    export function contains(path: Path, t: number): number;
+    export function contains(path: Two.Path, t: number): number;
     /**
      * @private
-     * @param {Path} path - The path to analyze against.
+     * @param {Two.Path} path - The path to analyze against.
      * @param {Number} target - The target length at which to find an anchor.
      * @returns {Number}
      * @description Return the id of an anchor based on a target length.
      */
-    export function getIdByLength(path: Path, target: number): number;
+    export function getIdByLength(path: Two.Path, target: number): number;
     export function getCurveLength(a: any, b: any, limit: any): number;
-    export function getSubdivisions(a: any, b: any, limit: any): import("two.js/src/anchor").Anchor[];
-    import { Path } from "two.js/src/path";
+    export function getSubdivisions(a: any, b: any, limit: any): import("src/anchor").Anchor[];
 }
-declare module "two.js/src/effects/stop" {
+declare module "src/effects/stop" {
     /**
      * @name Two.Stop
      * @class
-
+     * @extends Two.Element
      * @param {Number} [offset] - The offset percentage of the stop represented as a zero-to-one value. Default value flip flops from zero-to-one as new stops are created.
      * @param {String} [color] - The color of the stop. Default value flip flops from white to black as new stops are created.
      * @param {Number} [opacity] - The opacity value. Default value is 1, cannot be lower than 0.
      * @nota-bene Used specifically in conjunction with {@link Two.Gradient}s to control color graduation.
      */
-    export class Stop extends TwoElement {
+    export class Stop {
         /**
          * @name Two.Stop.Index
          * @property {Number} - The current index being referenced for calculating a stop's default offset value.
@@ -1693,7 +1734,7 @@ declare module "two.js/src/effects/stop" {
          * @property {String[]} - A list of properties that are on every {@link Two.Stop}.
          */
         static Properties: string[];
-        constructor(offset?: number, color?: string, opacity?: number);
+        constructor(offset: any, color: any, opacity: any);
         /**
          * @name Two.Stop#_flagOffset
          * @private
@@ -1738,6 +1779,7 @@ declare module "two.js/src/effects/stop" {
         /**
          * @name Two.Stop#opacity
          * @property {Number} - The alpha percentage of the stop represented as a zero-to-one value.
+         * @nota-bene This is only supported on the {@link Two.SVGRenderer}. You can get the same effect by encoding opacity into `rgba` strings in the color.
          */
         opacity: number;
         /**
@@ -1748,11 +1790,11 @@ declare module "two.js/src/effects/stop" {
         /**
          * @name Two.Stop#clone
          * @function
-         * @param {Gradient} [parent] - The parent group or scene to add the clone to.
-         * @returns {Stop}
+         * @param {Two.Gradient} [parent] - The parent gradient to add the clone to.
+         * @returns {Two.Stop}
          * @description Create a new instance of {@link Two.Stop} with the same properties of the current path.
          */
-        clone(parent: Gradient): Stop;
+        clone(parent?: Two.Gradient): Two.Stop;
         /**
          * @name Two.Stop#toObject
          * @function
@@ -1760,30 +1802,35 @@ declare module "two.js/src/effects/stop" {
          * @description Return a JSON compatible plain object that represents the path.
          */
         toObject(): any;
+        /**
+         * @name Two.Stop#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Element as TwoElement } from "two.js/src/element";
-    import { Gradient } from "two.js/src/effects/gradient";
 }
-declare module "two.js/src/effects/gradient" {
+declare module "src/effects/gradient" {
     /**
      * @name Two.Gradient
      * @class
-
-     * @param {Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
+     * @extends Two.Element
+     * @param {Two.Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
      * @description This is the base class for constructing different types of gradients with Two.js. The two common gradients are {@link Two.LinearGradient} and {@link Two.RadialGradient}.
      */
-    export class Gradient extends TwoElement {
+    export class Gradient {
         /**
          * @name Two.Gradient.Stop
          * @see {@link Two.Stop}
          */
-        static Stop: Stop;
+        static Stop: typeof Stop;
         /**
          * @name Two.Gradient.Properties
          * @property {String[]} - A list of properties that are on every {@link Two.Gradient}.
          */
         static Properties: string[];
-        constructor(stops?: Stop[]);
+        constructor(stops: any);
         _flagStops: boolean;
         _flagSpread: boolean;
         _flagUnits: boolean;
@@ -1801,6 +1848,7 @@ declare module "two.js/src/effects/gradient" {
          * @nota-bene In the {@link Two.SvgRenderer} change this to change the underlying SVG element's id too.
          */
         id: string;
+        classList: any[];
         /**
          * @name Two.Gradient#spread
          * @property {String} - Indicates what happens if the gradient starts or ends inside the bounds of the target rectangle. Possible values are `'pad'`, `'reflect'`, and `'repeat'`.
@@ -1817,11 +1865,11 @@ declare module "two.js/src/effects/gradient" {
         /**
          * @name Two.Gradient#clone
          * @function
-         * @param {Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Gradient}
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Gradient}
          * @description Create a new instance of {@link Two.Gradient} with the same properties of the current path.
          */
-        clone(parent?: Group): Gradient;
+        clone(parent?: Two.Group): Two.Gradient;
         /**
          * @name Two.Gradient#toObject
          * @function
@@ -1838,25 +1886,36 @@ declare module "two.js/src/effects/gradient" {
          * @nota-bene Try not to call this method more than once a frame.
          */
         private _update;
+        /**
+         * @name Two.Gradient#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Element as TwoElement } from "two.js/src/element";
-    import { Stop } from "two.js/src/effects/stop";
-    import { Group } from "two.js/src/group";
+    import { Stop } from "src/effects/stop";
 }
-declare module "two.js/src/effects/linear-gradient" {
+declare module "src/effects/linear-gradient" {
     /**
      * @name Two.LinearGradient
      * @class
-
+     * @extends Two.Gradient
      * @param {Number} [x1=0] - The x position of the first end point of the linear gradient.
      * @param {Number} [y1=0] - The y position of the first end point of the linear gradient.
      * @param {Number} [x2=0] - The x position of the second end point of the linear gradient.
      * @param {Number} [y2=0] - The y position of the second end point of the linear gradient.
-     * @param {Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
+     * @param {Two.Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
      * @nota-bene The linear gradient lives within the space of the parent object's matrix space.
      */
-    export class LinearGradient extends Gradient {
-        constructor(x1?: number, y1?: number, x2?: number, y2?: number, stops?: Stop[]);
+    export class LinearGradient {
+        static Properties: string[];
+        /**
+         * @name Two.LinearGradient.Stop
+         * @see {@link Two.Stop}
+         */
+        static Stop: typeof Stop;
+        constructor(x1: any, y1: any, x2: any, y2: any, stops: any);
         /**
          * @name Two.LinearGradient#_flagEndPoints
          * @private
@@ -1867,34 +1926,74 @@ declare module "two.js/src/effects/linear-gradient" {
         _right: any;
         /**
          * @name Two.LinearGradient#left
-         * @property {Vector} - The x and y value for where the first end point is placed on the canvas.
+         * @property {Two.Vector} - The x and y value for where the first end point is placed on the canvas.
          */
         left: Vector;
         /**
          * @name Two.LinearGradient#right
-         * @property {Vector} - The x and y value for where the second end point is placed on the canvas.
+         * @property {Two.Vector} - The x and y value for where the second end point is placed on the canvas.
          */
         right: Vector;
+        /**
+         * @name Two.LinearGradient#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Gradient}
+         * @description Create a new instance of {@link Two.LinearGradient} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.Gradient;
+        /**
+         * @name Two.LinearGradient#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
+        /**
+         * @name Two.LinearGradient#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.LinearGradient#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Gradient } from "two.js/src/effects/gradient";
-    import { Stop } from "two.js/src/effects/stop";
-    import { Vector } from "two.js/src/vector";
+    import { Vector } from "src/vector";
+    import { Stop } from "src/effects/stop";
 }
-declare module "two.js/src/effects/radial-gradient" {
+declare module "src/effects/radial-gradient" {
     /**
      * @name Two.RadialGradient
      * @class
-
+     * @extends Two.Gradient
      * @param {Number} [x=0] - The x position of the origin of the radial gradient.
      * @param {Number} [y=0] - The y position of the origin of the radial gradient.
      * @param {Number} [radius=0] - The radius of the radial gradient.
-     * @param {Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
+     * @param {Two.Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
      * @param {Number} [focalX=0] - The x position of the focal point on the radial gradient.
      * @param {Number} [focalY=0] - The y position of the focal point on the radial gradient.
      * @nota-bene The radial gradient lives within the space of the parent object's matrix space.
      */
-    export class RadialGradient extends Gradient {
-        constructor(cx?: number, cy?: number, r?: number, stops?: Stop[], fx?: number, fy?: number);
+    export class RadialGradient {
+        /**
+         * @name Two.RadialGradient.Stop
+         * @see {@link Two.Stop}
+         */
+        static Stop: typeof Stop;
+        /**
+         * @name Two.RadialGradient.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.RadialGradient}.
+         */
+        static Properties: string[];
+        constructor(cx: any, cy: any, r: any, stops: any, fx: any, fy: any);
         /**
          * @name Two.RadialGradient#_flagRadius
          * @private
@@ -1918,31 +2017,61 @@ declare module "two.js/src/effects/radial-gradient" {
         _focal: any;
         /**
          * @name Two.RadialGradient#center
-         * @property {Vector} - The x and y value for where the origin of the radial gradient is.
+         * @property {Two.Vector} - The x and y value for where the origin of the radial gradient is.
          */
         center: Vector;
         radius: number;
         /**
          * @name Two.RadialGradient#focal
-         * @property {Vector} - The x and y value for where the focal point of the radial gradient is.
+         * @property {Two.Vector} - The x and y value for where the focal point of the radial gradient is.
          * @nota-bene This effects the spray or spread of the radial gradient.
          */
         focal: Vector;
+        /**
+         * @name Two.RadialGradient#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Gradient}
+         * @description Create a new instance of {@link Two.RadialGradient} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.Gradient;
+        /**
+         * @name Two.RadialGradient#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
+        /**
+         * @name Two.RadialGradient#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.RadialGradient#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Gradient } from "two.js/src/effects/gradient";
-    import { Stop } from "two.js/src/effects/stop";
-    import { Vector } from "two.js/src/vector";
+    import { Vector } from "src/vector";
+    import { Stop } from "src/effects/stop";
 }
-declare module "two.js/src/effects/texture" {
+declare module "src/effects/texture" {
     /**
      * @name Two.Texture
      * @class
-
+     * @extends Two.Element
      * @param {String|HTMLImageElement} [src] - The URL path to an image file or an `<img />` element.
      * @param {Function} [callback] - An optional callback function once the image has been loaded.
      * @description Fundamental to work with bitmap data, a.k.a. pregenerated imagery, in Two.js. Supported formats include jpg, png, gif, and tiff. See {@link Two.Texture.RegularExpressions} for a full list of supported formats.
      */
-    export class Texture extends TwoElement {
+    export class Texture {
         /**
          * @name Two.Texture.Properties
          * @property {String[]} - A list of properties that are on every {@link Two.Texture}.
@@ -1959,7 +2088,7 @@ declare module "two.js/src/effects/texture" {
         };
         /**
          * @name Two.Texture.ImageRegistry
-         * @property {Registry} - A canonical listing of image data used in a single session of Two.js.
+         * @property {Two.Registry} - A canonical listing of image data used in a single session of Two.js.
          * @nota-bene This object is used to cache image data between different textures.
          */
         static ImageRegistry: Registry;
@@ -1973,18 +2102,18 @@ declare module "two.js/src/effects/texture" {
         /**
          * @name Two.Texture.loadHeadlessBuffer
          * @property {Function} - Loads an image as a buffer in headless environments.
-         * @param {Texture} texture - The {@link Two.Texture} to be loaded.
+         * @param {Two.Texture} texture - The {@link Two.Texture} to be loaded.
          * @param {Function} loaded - The callback function to be triggered once the image is loaded.
          * @nota-bene - This function uses node's `fs.readFileSync` to spoof the `<img />` loading process in the browser.
          */
-        static loadHeadlessBuffer(texture: Texture, loaded: Function): void;
+        static loadHeadlessBuffer(texture: Two.Texture, loaded: Function): void;
         /**
          * @name Two.Texture.getTag
          * @property {Function} - Retrieves the tag name of an image, video, or canvas node.
          * @param {HTMLImageElement} image - The image to infer the tag name from.
          * @returns {String} - Returns the tag name of an image, video, or canvas node.
          */
-        static getTag(image: any): string;
+        static getTag(image: HTMLImageElement): string;
         /**
          * @name Two.Texture.getImage
          * @property {Function} - Convenience function to set {@link Two.Texture#image} properties with canonincal versions set in {@link Two.Texture.ImageRegistry}.
@@ -2005,11 +2134,11 @@ declare module "two.js/src/effects/texture" {
         /**
          * @name Two.Texture.load
          * @function
-         * @param {Texture} texture - The texture to load.
+         * @param {Two.Texture} texture - The texture to load.
          * @param {Function} callback - The function to be called once the texture is loaded.
          */
-        static load(texture: Texture, callback: Function): void;
-        constructor(src?: any, callback?: Function);
+        static load(texture: Two.Texture, callback: Function): void;
+        constructor(src: any, callback: any);
         /**
          * @name Two.Texture#_flagSrc
          * @private
@@ -2088,7 +2217,9 @@ declare module "two.js/src/effects/texture" {
          * @see {@link Two.Texture#offset}
          */
         private _offset;
+        _renderer: {};
         id: string;
+        classList: any[];
         /**
          * @name Two.Texture#loaded
          * @property {Boolean} - Shorthand value to determine if image has been loaded into the texture.
@@ -2102,7 +2233,7 @@ declare module "two.js/src/effects/texture" {
         repeat: string;
         /**
          * @name Two.Texture#offset
-         * @property {Vector} - A two-component vector describing any pixel offset of the texture when applied to a {@link Two.Path}.
+         * @property {Two.Vector} - A two-component vector describing any pixel offset of the texture when applied to a {@link Two.Path}.
          */
         offset: Vector;
         src: string;
@@ -2115,10 +2246,10 @@ declare module "two.js/src/effects/texture" {
         /**
          * @name Two.Texture#clone
          * @function
-         * @returns {Texture}
+         * @returns {Two.Texture}
          * @description Create a new instance of {@link Two.Texture} with the same properties of the current texture.
          */
-        clone(): Texture;
+        clone(): Two.Texture;
         /**
          * @name Two.Texture#toObject
          * @function
@@ -2135,32 +2266,38 @@ declare module "two.js/src/effects/texture" {
          * @nota-bene Try not to call this method more than once a frame.
          */
         private _update;
+        /**
+         * @name Two.Texture#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Element as TwoElement } from "two.js/src/element";
-    import { Vector } from "two.js/src/vector";
-    import { Registry } from "two.js/src/registry";
+    import { Vector } from "src/vector";
+    import { Registry } from "src/registry";
 }
-declare module "two.js/src/path" {
+declare module "src/path" {
     /**
      * @name Two.Path
      * @class
-
-     * @param {Anchor[]} [vertices] - A list of {@link Two.Anchor}s that represent the order and coordinates to construct the rendered shape.
+     * @extends Two.Shape
+     * @param {Two.Anchor[]} [vertices] - A list of {@link Two.Anchor}s that represent the order and coordinates to construct the rendered shape.
      * @param {Boolean} [closed=false] - Describes whether the shape is closed or open.
      * @param {Boolean} [curved=false] - Describes whether the shape automatically calculates bezier handles for each vertex.
      * @param {Boolean} [manual=false] - Describes whether the developer controls how vertices are plotted or if Two.js automatically plots coordinates based on closed and curved booleans.
      * @description This is the primary primitive class for creating all drawable shapes in Two.js. Unless specified methods return their instance of `Two.Path` for the purpose of chaining.
      */
-    export class Path extends Shape {
+    export class Path {
         /**
          * @name Two.Path.Properties
          * @property {String[]} - A list of properties that are on every {@link Two.Path}.
          */
         static Properties: string[];
         static Utils: {
-            getCurveLength: Function;
+            getCurveLength: typeof getCurveLength;
         };
-        constructor(vertices?: Anchor[], closed?: boolean, curved?: boolean, manual?: boolean);
+        constructor(vertices: any, closed: any, curved: any, manual: any);
         /**
          * @name Two.Path#_flagVertices
          * @private
@@ -2361,16 +2498,16 @@ declare module "two.js/src/path" {
         ending: number;
         /**
          * @name Two.Path#fill
-         * @property {(String|Gradient|Texture)} - The value of what the path should be filled in with.
+         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be filled in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        fill: string|Gradient|Texture;
+        fill: string;
         /**
          * @name Two.Path#stroke
-         * @property {(String|Gradient|Texture)} - The value of what the path should be outlined in with.
+         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be outlined in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        stroke: string|Gradient|Texture;
+        stroke: string;
         /**
          * @name Two.Path#linewidth
          * @property {Number} - The thickness in pixels of the stroke.
@@ -2414,7 +2551,7 @@ declare module "two.js/src/path" {
         miter: number;
         /**
          * @name Two.Path#vertices
-         * @property {Anchor[]} - An ordered list of anchor points for rendering the path.
+         * @property {Two.Anchor[]} - An ordered list of anchor points for rendering the path.
          * @description A list of {@link Two.Anchor} objects that consist of what form the path takes.
          * @nota-bene The array when manipulating is actually a {@link Two.Collection}.
          */
@@ -2430,7 +2567,15 @@ declare module "two.js/src/path" {
          * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
          */
-        dashes: number[];
+        dashes: any[];
+        /**
+         * @name Two.Path#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Path}
+         * @description Create a new instance of {@link Two.Path} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.Path;
         /**
          * @name Two.Path#toObject
          * @function
@@ -2474,11 +2619,11 @@ declare module "two.js/src/path" {
          * @name Two.Path#getPointAt
          * @function
          * @param {Number} t - Percentage value describing where on the {@link Two.Path} to estimate and assign coordinate values.
-         * @param {Vector} [obj] - Object to apply calculated x, y to. If none available returns new `Object`.
+         * @param {Two.Vector} [obj] - Object to apply calculated x, y to. If none available returns new `Object`.
          * @returns {Object}
          * @description Given a float `t` from 0 to 1, return a point or assign a passed `obj`'s coordinates to that percentage on this {@link Two.Path}'s curve.
          */
-        getPointAt(t: number, obj: any): any;
+        getPointAt(t: number, obj?: Two.Vector): any;
         /**
          * @name Two.Path#plot
          * @function
@@ -2503,11 +2648,24 @@ declare module "two.js/src/path" {
          */
         private _updateLength;
         _lengths: any[];
+        /**
+         * @name Two.Path#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.Path#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Anchor } from "two.js/src/anchor";
-    import { Shape } from "two.js/src/shape";
-    import { Gradient } from "two.js/src/effects/gradient";
-    import { Texture } from "two.js/src/effects/texture";
+    import { getCurveLength } from "src/utils/shape";
     /**
      * @name FlagVertices
      * @private
@@ -2554,18 +2712,23 @@ declare module "two.js/src/path" {
         _flagStroke: boolean;
     }
 }
-declare module "two.js/src/shapes/rectangle" {
+declare module "src/shapes/rectangle" {
     /**
      * @name Two.Rectangle
      * @class
-
+     * @extends Two.Path
      * @param {Number} [x=0] - The x position of the rectangle.
      * @param {Number} [y=0] - The y position of the rectangle.
      * @param {Number} [width=1] - The width value of the rectangle.
      * @param {Number} [height=1] - The width value of the rectangle.
      */
-    export class Rectangle extends Path {
-        constructor(x?: number, y?: number, width?: number, height?: number);
+    export class Rectangle {
+        /**
+         * @name Two.Rectangle.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.Rectangle}.
+         */
+        static Properties: string[];
+        constructor(x: any, y: any, width: any, height: any);
         /**
          * @name Two.Rectangle#width
          * @property {Number} - The size of the width of the rectangle.
@@ -2605,17 +2768,47 @@ declare module "two.js/src/shapes/rectangle" {
          * @see {@link Two.Rectangle#height}
          */
         private _height;
-        private _origin: Vector;
+        _origin: any;
+        /**
+         * @name Two.Rectangle#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.Rectangle#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
+        /**
+         * @name Two.Rectangle#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Rectangle}
+         * @description Create a new instance of {@link Two.Rectangle} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.Rectangle;
+        /**
+         * @name Two.Rectangle#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
     }
-    import { Path } from "two.js/src/path";
-    import { Vector } from "two.js/src/vector";
+    import { Vector } from "src/vector";
 }
-declare module "two.js/src/effects/sprite" {
+declare module "src/effects/sprite" {
     /**
      * @name Two.Sprite
      * @class
-
-     * @param {String|Texture} [path] - The URL path or {@link Two.Texture} to be used as the bitmap data displayed on the sprite.
+     * @extends Two.Rectangle
+     * @param {String|Two.Texture} [path] - The URL path or {@link Two.Texture} to be used as the bitmap data displayed on the sprite.
      * @param {Number} [ox=0] - The initial `x` position of the Two.Sprite.
      * @param {Number} [oy=0] - The initial `y` position of the Two.Sprite.
      * @param {Number} [cols=1] - The number of columns the sprite contains.
@@ -2623,8 +2816,13 @@ declare module "two.js/src/effects/sprite" {
      * @param {Number} [frameRate=0] - The frame rate at which the partitions of the image should playback at.
      * @description A convenient package to display still or animated images through a tiled image source. For more information on the principals of animated imagery through tiling see [Texture Atlas](https://en.wikipedia.org/wiki/Texture_atlas) on Wikipedia.
      */
-    export class Sprite extends Rectangle {
-        constructor(path?: any, ox?: number, oy?: number, cols?: number, rows?: number, frameRate?: number);
+    export class Sprite {
+        /**
+         * @name Two.Sprite.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.Sprite}.
+         */
+        static Properties: string[];
+        constructor(path: any, ox: any, oy: any, cols: any, rows: any, frameRate: any);
         /**
          * @name Two.Sprite#_flagTexture
          * @private
@@ -2727,7 +2925,14 @@ declare module "two.js/src/effects/sprite" {
          * @property {Number} - The current frame the {@link Two.Sprite} is currently displaying.
          */
         private _index;
+        /**
+         * @name Two.Sprite#_origin
+         * @private
+         * @see {@link Two.Sprite#origin}
+         */
+        private _origin;
         texture: Texture;
+        origin: Vector;
         columns: number;
         rows: number;
         frameRate: number;
@@ -2758,21 +2963,61 @@ declare module "two.js/src/effects/sprite" {
          * @description Halt animation playback of a {@link Two.Sprite} and set the current frame back to the first frame.
          */
         stop(): Sprite;
+        /**
+         * @name Two.Sprite#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Sprite}
+         * @description Create a new instance of {@link Two.Sprite} with the same properties of the current sprite.
+         */
+        clone(parent?: Two.Group): Two.Sprite;
+        /**
+         * @name Two.Sprite#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
+        /**
+         * @name Two.Sprite#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        fill: any;
+        width: any;
+        height: any;
+        /**
+         * @name Two.Sprite#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Rectangle } from "two.js/src/shapes/rectangle";
-    import { Texture } from "two.js/src/effects/texture";
+    import { Texture } from "src/effects/texture";
+    import { Vector } from "src/vector";
 }
-declare module "two.js/src/shapes/circle" {
+declare module "src/shapes/circle" {
     /**
      * @name Two.Circle
      * @class
-
+     * @extends Two.Path
      * @param {Number} [x=0] - The x position of the circle.
      * @param {Number} [y=0] - The y position of the circle.
      * @param {Number} [radius=0] - The radius value of the circle.
      * @param {Number} [resolution=4] - The number of vertices used to construct the circle.
      */
-    export class Circle extends Path {
+    export class Circle {
+        /**
+         * @name Two.Circle.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.Circle}.
+         */
+        static Properties: string[];
+        constructor(ox: any, oy: any, r: any, resolution: any);
         /**
          * @name Two.Circle#_flagRadius
          * @private
@@ -2785,24 +3030,58 @@ declare module "two.js/src/shapes/circle" {
          * @see {@link Two.Circle#radius}
          */
         private _radius;
-        constructor(x?: number, y?: number, radius?: number, resolution?:number);
         radius: number;
+        /**
+         * @name Two.Circle#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.Circle#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
+        /**
+         * @name Two.Circle#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Circle}
+         * @description Create a new instance of {@link Two.Circle} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.Circle;
+        /**
+         * @name Two.Circle#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
     }
-    import { Path } from "two.js/src/path";
 }
-declare module "two.js/src/shapes/ellipse" {
+declare module "src/shapes/ellipse" {
     /**
      * @name Two.Ellipse
      * @class
-
+     * @extends Two.Path
      * @param {Number} [x=0] - The x position of the ellipse.
      * @param {Number} [y=0] - The y position of the ellipse.
      * @param {Number} [rx=0] - The radius value of the ellipse in the x direction.
      * @param {Number} [ry=0] - The radius value of the ellipse in the y direction.
      * @param {Number} [resolution=4] - The number of vertices used to construct the ellipse.
      */
-    export class Ellipse extends Path {
-        constructor(x?: number, y?: number, rx?: number, ry?: number, resolution?: number);
+    export class Ellipse {
+        /**
+         * @name Two.Ellipse.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.Ellipse}.
+         */
+        static Properties: string[];
+        constructor(x: any, y: any, rx: any, ry: any, resolution: any);
         /**
          * @name Two.Ellipse#_flagWidth
          * @private
@@ -2829,29 +3108,59 @@ declare module "two.js/src/shapes/ellipse" {
         private _height;
         width: number;
         height: number;
+        /**
+         * @name Two.Ellipse#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.Ellipse#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
+        /**
+         * @name Two.Ellipse#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Ellipse}
+         * @description Create a new instance of {@link Two.Ellipse} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.Ellipse;
+        /**
+         * @name Two.Ellipse#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
     }
-    import { Path } from "two.js/src/path";
 }
-declare module "two.js/src/shapes/line" {
+declare module "src/shapes/line" {
     /**
      * @name Two.Line
      * @class
-
+     * @extends Two.Path
      * @param {Number} [x1=0] - The x position of the first vertex on the line.
      * @param {Number} [y1=0] - The y position of the first vertex on the line.
      * @param {Number} [x2=0] - The x position of the second vertex on the line.
      * @param {Number} [y2=0] - The y position of the second vertex on the line.
      */
-    export class Line extends Path {
-      constructor(x1?: number, y1?: number, x2?: number, y2?: number);
+    export class Line {
+        constructor(x1: any, y1: any, x2: any, y2: any);
+        automatic: boolean;
     }
-    import { Path } from "two.js/src/path";
 }
-declare module "two.js/src/shapes/rounded-rectangle" {
+declare module "src/shapes/rounded-rectangle" {
     /**
      * @name Two.RoundedRectangle
      * @class
-
+     * @extends Two.Path
      * @param {Number} [x=0] - The x position of the rounded rectangle.
      * @param {Number} [y=0] - The y position of the rounded rectangle.
      * @param {Number} [width=0] - The width value of the rounded rectangle.
@@ -2859,8 +3168,13 @@ declare module "two.js/src/shapes/rounded-rectangle" {
      * @param {Number} [radius=0] - The radius value of the rounded rectangle.
      * @param {Number} [resolution=12] - The number of vertices used to construct the rounded rectangle.
      */
-    export class RoundedRectangle extends Path {
-        constructor(x?: number, y?: number, width?: number, height?: number, radius?: number);
+    export class RoundedRectangle {
+        /**
+         * @name Two.RoundedRectangle.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.RoundedRectangle}.
+         */
+        static Properties: string[];
+        constructor(x: any, y: any, width: any, height: any, radius: any);
         /**
          * @name Two.RoundedRectangle#_flagWidth
          * @private
@@ -2898,25 +3212,56 @@ declare module "two.js/src/shapes/rounded-rectangle" {
          */
         private _radius;
         closed: boolean;
+        automatic: boolean;
         width: number;
         height: number;
         radius: number;
+        /**
+         * @name Two.RoundedRectangle#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.RoundedRectangle#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
+        /**
+         * @name Two.RoundedRectangle#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.RoundedRectangle}
+         * @description Create a new instance of {@link Two.RoundedRectangle} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.RoundedRectangle;
+        /**
+         * @name Two.RoundedRectangle#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
     }
-    import { Path } from "two.js/src/path";
 }
-declare module "two.js/src/text" {
+declare module "src/text" {
     /**
      * @name Two.Text
      * @class
-
+     * @extends Two.Shape
      * @param {String} [message] - The String to be rendered to the scene.
      * @param {Number} [x=0] - The position in the x direction for the object.
      * @param {Number} [y=0] - The position in the y direction for the object.
      * @param {Object} [styles] - An object where styles are applied. Attribute must exist in Two.Text.Properties.
      * @description This is a primitive class for creating drawable text that can be added to the scenegraph.
-     * @returns {Text}
+     * @returns {Two.Text}
      */
-    export class Text extends Shape {
+    export class Text {
         /**
          * @name Two.Text.Ratio
          * @property {Number} - Approximate aspect ratio of a typeface's character width to height.
@@ -2927,7 +3272,15 @@ declare module "two.js/src/text" {
          * @property {String[]} - A list of properties that are on every {@link Two.Text}.
          */
         static Properties: string[];
-        constructor(message?: string, x?: number, y?: number, styles?: any);
+        /**
+         *
+         * @name Two.Measure
+         * @function
+         * @param {Two.Text} [text] - The instance of {@link Two.Text} to measure.
+         * @returns {Object} - The width and height of the {@link Two.Text} instance.
+         */
+        static Measure(text?: Two.Text): any;
+        constructor(message: any, x: any, y: any, styles: any);
         /**
          * @name Two.Text#_flagValue
          * @private
@@ -3028,105 +3381,111 @@ declare module "two.js/src/text" {
          * @name Two.Text#value
          * @property {String} - The characters to be rendered to the the screen. Referred to in the documentation sometimes as the `message`.
          */
+        _value: string;
+        /**
+         * @name Two.Text#family
+         * @property {String} - The font family Two.js should attempt to regsiter for rendering. The default value is `'sans-serif'`. Comma separated font names can be supplied as a "stack", similar to the CSS implementation of `font-family`.
+         */
+        _family: string;
+        /**
+         * @name Two.Text#size
+         * @property {Number} - The font size in Two.js point space. Defaults to `13`.
+         */
+        _size: number;
+        /**
+         * @name Two.Text#leading
+         * @property {Number} - The height between lines measured from base to base in Two.js point space. Defaults to `17`.
+         */
+        _leading: number;
+        /**
+         * @name Two.Text#alignment
+         * @property {String} - Alignment of text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'left'`, `'center'`, `'right'`. Defaults to `'center'`.
+         */
+        _alignment: string;
+        /**
+         * @name Two.Text#baseline
+         * @property {String} - The vertical aligment of the text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'top'`, `'middle'`, `'bottom'`, and `'baseline'`. Defaults to `'baseline'`.
+         * @nota-bene In headless environments where the canvas is based on {@link https://github.com/Automattic/node-canvas}, `baseline` seems to be the only valid property.
+         */
+        _baseline: string;
+        /**
+         * @name Two.Text#style
+         * @property {String} - The font's style. Possible values include '`normal`', `'italic'`. Defaults to `'normal'`.
+         */
+        _style: string;
+        /**
+         * @name Two.Text#weight
+         * @property {Number} - A number at intervals of 100 to describe the font's weight. This compatibility varies with the typeface's variant weights. Larger values are bolder. Smaller values are thinner. Defaults to `'500'`.
+         */
+        _weight: number;
+        /**
+         * @name Two.Text#decoration
+         * @property {String} - String to delineate whether text should be decorated with for instance an `'underline'`. Defaults to `'none'`.
+         */
+        _decoration: string;
+        /**
+         * @name Two.Text#fill
+         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the text object should be filled in with.
+         * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
+         */
+        _fill: string;
+        /**
+         * @name Two.Text#stroke
+         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the text object should be filled in with.
+         * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
+         */
+        _stroke: string;
+        /**
+         * @name Two.Text#linewidth
+         * @property {Number} - The thickness in pixels of the stroke.
+         */
+        _linewidth: number;
+        /**
+         * @name Two.Text#opacity
+         * @property {Number} - The opaqueness of the text object.
+         * @nota-bene Can be used in conjunction with CSS Colors that have an alpha value.
+         */
+        _opacity: number;
+        /**
+         * @name Two.Text#visible
+         * @property {Boolean} - Display the text object or not.
+         * @nota-bene For {@link Two.CanvasRenderer} and {@link Two.WebGLRenderer} when set to false all updating is disabled improving performance dramatically with many objects in the scene.
+         */
+        _visible: boolean;
+        /**
+         * @name Two.Text#mask
+         * @property {Two.Shape} - The shape whose alpha property becomes a clipping area for the text.
+         * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
+         */
+        _mask: any;
+        /**
+         * @name Two.Text#clip
+         * @property {Two.Shape} - Object to define clipping area.
+         * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
+         */
+        _clip: boolean;
         /**
          * @name Two.Text#_dashes
          * @private
          * @see {@link Two.Text#dashes}
          */
         private _dashes;
-        /**
-         * @name Two.Text#value
-         * @property {String} - The characters to be rendered to the the screen. Referred to in the documentation sometimes as the `message`.
-         */
-        value: string;
-        /**
-         * @name Two.Text#family
-         * @property {String} - The font family Two.js should attempt to regsiter for rendering. The default value is `'sans-serif'`. Comma separated font names can be supplied as a "stack", similar to the CSS implementation of `font-family`.
-         */
-        family: string;
-        /**
-         * @name Two.Text#size
-         * @property {Number} - The font size in Two.js point space. Defaults to `13`.
-         */
-        size: number;
-        /**
-         * @name Two.Text#leading
-         * @property {Number} - The height between lines measured from base to base in Two.js point space. Defaults to `17`.
-         */
-        leading: number;
-        /**
-         * @name Two.Text#alignment
-         * @property {String} - Alignment of text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'left'`, `'center'`, `'right'`. Defaults to `'center'`.
-         */
-        alignment: string;
-        /**
-         * @name Two.Text#baseline
-         * @property {String} - The vertical aligment of the text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'top'`, `'middle'`, `'bottom'`, and `'baseline'`. Defaults to `'baseline'`.
-         */
-        baseline: string;
-        /**
-         * @name Two.Text#style
-         * @property {String} - The font's style. Possible values include '`normal`', `'italic'`. Defaults to `'normal'`.
-         */
-        style: string;
-        /**
-         * @name Two.Text#weight
-         * @property {Number} - A number at intervals of 100 to describe the font's weight. This compatibility varies with the typeface's variant weights. Larger values are bolder. Smaller values are thinner. Defaults to `'500'`.
-         */
-        weight: number;
-        /**
-         * @name Two.Text#decoration
-         * @property {String} - String to delineate whether text should be decorated with for instance an `'underline'`. Defaults to `'none'`.
-         */
-        decoration: string;
-        /**
-         * @name Two.Text#fill
-         * @property {(String|Gradient|Texture)} - The value of what the text object should be filled in with.
-         * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
-         */
-        fill: string|Gradient|Texture;
-        /**
-         * @name Two.Text#stroke
-         * @property {(String|Gradient|Texture)} - The value of what the text object should be filled in with.
-         * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
-         */
-        stroke: string|Gradient|Texture;
-        /**
-         * @name Two.Text#linewidth
-         * @property {Number} - The thickness in pixels of the stroke.
-         */
-        linewidth: number;
-        /**
-         * @name Two.Text#opacity
-         * @property {Number} - The opaqueness of the text object.
-         * @nota-bene Can be used in conjunction with CSS Colors that have an alpha value.
-         */
-        opacity: number;
-        /**
-         * @name Two.Text#visible
-         * @property {Boolean} - Display the text object or not.
-         * @nota-bene For {@link Two.CanvasRenderer} and {@link Two.WebGLRenderer} when set to false all updating is disabled improving performance dramatically with many objects in the scene.
-         */
-        visible: boolean;
-        /**
-         * @name Two.Text#mask
-         * @property {Shape} - The shape whose alpha property becomes a clipping area for the text.
-         * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
-         */
-        mask: any;
-        /**
-         * @name Two.Text#clip
-         * @property {Shape} - Object to define clipping area.
-         * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
-         */
-        clip: boolean;
+        value: any;
         /**
          * @name Two.Text#dashes
          * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
          * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
          */
-        dashes: number[];
+        dashes: any[];
+        /**
+         * @name Two.Text#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Text}
+         * @description Create a new instance of {@link Two.Text} with the same properties of the current text object.
+         */
+        clone(parent?: Two.Group): Two.Text;
         /**
          * @name Two.Text#toObject
          * @function
@@ -3140,12 +3499,15 @@ declare module "two.js/src/text" {
          * @description Short hand method to set fill to `transparent`.
          */
         noFill(): Text;
+        fill: string;
         /**
          * @name Two.Text#noStroke
          * @function
          * @description Short hand method to set stroke to `transparent`.
          */
         noStroke(): Text;
+        stroke: any;
+        linewidth: any;
         /**
          * @name Two.Text#getBoundingClientRect
          * @function
@@ -3154,12 +3516,17 @@ declare module "two.js/src/text" {
          * @description Return an object with top, left, right, bottom, width, and height parameters of the text object.
          */
         getBoundingClientRect(shallow?: boolean): any;
+        /**
+         * @name Two.Text#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
+        _flagClassName: boolean;
     }
-    import { Shape } from "two.js/src/shape";
-    import { Gradient } from "two.js/src/effects/gradient";
-    import { Texture } from "two.js/src/effects/texture";
 }
-declare module "two.js/src/utils/interpret-svg" {
+declare module "src/utils/interpret-svg" {
     /**
      * @name Two.Utils.read
      * @property {Object} read - A map of functions to read any number of SVG node types and create Two.js equivalents of them. Primarily used by the {@link Two#interpret} method.
@@ -3172,30 +3539,25 @@ declare module "two.js/src/utils/interpret-svg" {
         polygon: (node: any, parentStyles: any) => Path;
         polyline: (node: any, parentStyles: any) => any;
         path: (node: any, parentStyles: any) => Path;
-        circle: (node: any, parentStyles: any) => Circle;
-        ellipse: (node: any, parentStyles: any) => Ellipse;
-        rect: (node: any, parentStyles: any) => Rectangle | RoundedRectangle;
-        'rounded-rect': (node: any, parentStyles: any) => RoundedRectangle;
-        line: (node: any, parentStyles: any) => Line;
+        circle: (node: any, parentStyles: any) => any;
+        ellipse: (node: any, parentStyles: any) => any;
+        rect: (node: any, parentStyles: any) => any;
+        'rounded-rect': (node: any, parentStyles: any) => any;
+        line: (node: any, parentStyles: any) => any;
         lineargradient: (node: any, parentStyles: any) => LinearGradient;
         radialgradient: (node: any, parentStyles: any) => RadialGradient;
         text: (node: any, parentStyles: any) => Text;
         clippath: (node: any, parentStyles: any) => any;
         image: (node: any, parentStyles: any) => Sprite;
     };
-    import { Group } from "two.js/src/group";
-    import { Path } from "two.js/src/path";
-    import { Circle } from "two.js/src/shapes/circle";
-    import { Ellipse } from "two.js/src/shapes/ellipse";
-    import { Rectangle } from "two.js/src/shapes/rectangle";
-    import { RoundedRectangle } from "two.js/src/shapes/rounded-rectangle";
-    import { Line } from "two.js/src/shapes/line";
-    import { LinearGradient } from "two.js/src/effects/linear-gradient";
-    import { RadialGradient } from "two.js/src/effects/radial-gradient";
-    import { Text } from "two.js/src/text";
-    import { Sprite } from "two.js/src/effects/sprite";
+    import { Group } from "src/group";
+    import { Path } from "src/path";
+    import { LinearGradient } from "src/effects/linear-gradient";
+    import { RadialGradient } from "src/effects/radial-gradient";
+    import { Text } from "src/text";
+    import { Sprite } from "src/effects/sprite";
 }
-declare module "two.js/src/utils/xhr" {
+declare module "src/utils/xhr" {
     /**
      * @name Two.Utils.xhr
      * @function
@@ -3206,23 +3568,29 @@ declare module "two.js/src/utils/xhr" {
      */
     export function xhr(path: string, callback: Function): XMLHttpRequest;
 }
-declare module "two.js/src/effects/image-sequence" {
+declare module "src/effects/image-sequence" {
     /**
      * @name Two.ImageSequence
      * @class
-
-     * @param {String|String[]|Texture|Texture[]} paths - A list of URLs or {@link Two.Texture}s.
+     * @extends Two.Rectangle
+     * @param {String|String[]|Two.Texture|Two.Texture[]} paths - A list of URLs or {@link Two.Texture}s.
      * @param {Number} [ox=0] - The initial `x` position of the Two.ImageSequence.
      * @param {Number} [oy=0] - The initial `y` position of the Two.ImageSequence.
      * @param {Number} [frameRate=30] - The frame rate at which the images should playback at.
      * @description A convenient package to display still or animated images organized as a series of still images.
      */
-    export class ImageSequence extends Rectangle {
+    export class ImageSequence {
+        /**
+         * @name Two.ImageSequence.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.ImageSequence}.
+         */
+        static Properties: string[];
         /**
          * @name Two.ImageSequence.DefaultFrameRate
          * @property The default frame rate that {@link Two.ImageSequence#frameRate} is set to when instantiated.
          */
         static DefaultFrameRate: number;
+        constructor(paths: any, ox: any, oy: any, frameRate: any);
         /**
          * @name Two.ImageSequence#_flagTextures
          * @private
@@ -3301,7 +3669,14 @@ declare module "two.js/src/effects/image-sequence" {
          * @see {@link Two.ImageSequence#frameRate}
          */
         private _frameRate;
+        /**
+         * @name Two.ImageSequence#_origin
+         * @private
+         * @see {@link Two.ImageSequence#origin}
+         */
+        private _origin;
         textures: any[];
+        origin: Vector;
         frameRate: number;
         /**
          * @name Two.ImageSequence#index
@@ -3330,14 +3705,48 @@ declare module "two.js/src/effects/image-sequence" {
          * @description Halt animation playback of a {@link Two.ImageSequence} and set the current frame back to the first frame.
          */
         stop(): ImageSequence;
+        /**
+         * @name Two.ImageSequence#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.ImageSequence}
+         * @description Create a new instance of {@link Two.ImageSequence} with the same properties of the current image sequence.
+         */
+        clone(parent?: Two.Group): Two.ImageSequence;
+        /**
+         * @name Two.ImageSequence#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
+        /**
+         * @name Two.ImageSequence#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        width: any;
+        height: any;
+        fill: any;
+        /**
+         * @name Two.ImageSequence#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Rectangle } from "two.js/src/shapes/rectangle";
+    import { Vector } from "src/vector";
 }
-declare module "two.js/src/shapes/arc-segment" {
+declare module "src/shapes/arc-segment" {
     /**
      * @name Two.ArcSegment
      * @class
-
+     * @extends Two.Path
      * @param {Number} [x=0] - The x position of the arc segment.
      * @param {Number} [y=0] - The y position of the arc segment.
      * @param {Number} [innerRadius=0] - The inner radius value of the arc segment.
@@ -3346,8 +3755,13 @@ declare module "two.js/src/shapes/arc-segment" {
      * @param {Number} [endAngle=6.2831] - The end angle of the arc segment in Number.
      * @param {Number} [resolution=24] - The number of vertices used to construct the arc segment.
      */
-    export class ArcSegment extends Path {
-        constructor(ox?: number, oy?: number, ir?: number, or?: number, sa?: number, ea?: number, res?: number);
+    export class ArcSegment {
+        /**
+         * @name Two.ArcSegment.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.ArcSegment}.
+         */
+        static Properties: string[];
+        constructor(x: any, y: any, ir: any, or: any, sa: any, ea: any, res: any);
         /**
          * @name Two.ArcSegment#_flagStartAngle
          * @private
@@ -3400,40 +3814,70 @@ declare module "two.js/src/shapes/arc-segment" {
         outerRadius: number;
         startAngle: number;
         endAngle: number;
+        /**
+         * @name Two.ArcSegment#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.ArcSegment#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
+        /**
+         * @name Two.ArcSegment#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.ArcSegment}
+         * @description Create a new instance of {@link Two.ArcSegment} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.ArcSegment;
+        /**
+         * @name Two.ArcSegment#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
     }
-    import { Path } from "two.js/src/path";
 }
-declare module "two.js/src/shapes/points" {
+declare module "src/shapes/points" {
     /**
      * @name Two.Points
      * @class
-
-     * @param {Vector[]} [vertices] - A list of {@link Two.Vector}s that represent the order and coordinates to construct a rendered set of points.
+     * @extends Two.Shape
+     * @param {Two.Vector[]} [vertices] - A list of {@link Two.Vector}s that represent the order and coordinates to construct a rendered set of points.
      * @description This is a primary primitive class for quickly and easily drawing points in Two.js. Unless specified methods return their instance of `Two.Points` for the purpose of chaining.
      */
-    export class Points extends Shape {
+    export class Points {
         static Properties: string[];
-        constructor(vertices?: any[]);
-        private _flagVertices;
-        private _flagLength;
-        private _flagFill;
-        private _flagStroke;
-        private _flagLinewidth;
-        private _flagOpacity;
-        private _flagVisible;
-        private _flagSize;
-        private _flagSizeAttenuation;
-        private _length;
-        private _fill;
-        private _stroke;
-        private _linewidth;
-        private _opacity;
-        private _visible;
-        private _size;
-        private _sizeAttenuation;
-        private _beginning;
-        private _ending;
-        private _dashes;
+        constructor(vertices: any);
+        _flagVertices: boolean;
+        _flagLength: boolean;
+        _flagFill: boolean;
+        _flagStroke: boolean;
+        _flagLinewidth: boolean;
+        _flagOpacity: boolean;
+        _flagVisible: boolean;
+        _flagSize: boolean;
+        _flagSizeAttenuation: boolean;
+        _length: number;
+        _fill: string;
+        _stroke: string;
+        _linewidth: number;
+        _opacity: number;
+        _visible: boolean;
+        _size: number;
+        _sizeAttenuation: boolean;
+        _beginning: number;
+        _ending: number;
+        _dashes: any;
         /**
          * @name Two.Points#sizeAttenuation
          * @property {Boolean} - Boolean dictating whether Two.js should scale the size of the points based on its matrix hierarcy.
@@ -3454,16 +3898,16 @@ declare module "two.js/src/shapes/points" {
         ending: number;
         /**
          * @name Two.Points#fill
-         * @property {(String|Gradient|Texture)} - The value of what the path should be filled in with.
+         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be filled in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        fill: string|Gradient|Texture;
+        fill: string;
         /**
          * @name Two.Points#stroke
-         * @property {(String|Gradient|Texture)} - The value of what the path should be outlined in with.
+         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be outlined in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        stroke: string|Gradient|Texture;
+        stroke: string;
         /**
          * @name Two.Points#className
          * @property {String} - A class to be applied to the element to be compatible with CSS styling.
@@ -3478,7 +3922,7 @@ declare module "two.js/src/shapes/points" {
         visible: boolean;
         /**
          * @name Two.Points#vertices
-         * @property {Vector[]} - An ordered list of vector points for rendering points.
+         * @property {Two.Vector[]} - An ordered list of vector points for rendering points.
          * @description A list of {@link Two.Vector} objects that consist of which coordinates to draw points at.
          * @nota-bene The array when manipulating is actually a {@link Two.Collection}.
          */
@@ -3489,7 +3933,15 @@ declare module "two.js/src/shapes/points" {
          * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
          */
-        dashes: number[];
+        dashes: any[];
+        /**
+         * @name Two.Points#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Points}
+         * @description Create a new instance of {@link Two.Points} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.Points;
         /**
          * @name Two.Points#toObject
          * @function
@@ -3502,25 +3954,25 @@ declare module "two.js/src/shapes/points" {
          * @function
          * @description Short hand method to set fill to `transparent`.
          */
-        noFill: () => Points;
+        noFill: () => Path;
         /**
          * @name Two.Points#noStroke
          * @function
          * @description Short hand method to set stroke to `transparent`.
          */
-        noStroke: () => Points;
+        noStroke: () => Path;
         /**
          * @name Two.Points#corner
          * @function
          * @description Orient the vertices of the shape to the upper left-hand corner of the points object.
          */
-        corner: () => Points;
+        corner: () => Path;
         /**
          * @name Two.Points#center
          * @function
          * @description Orient the vertices of the shape to the center of the points object.
          */
-        center: () => Points;
+        center: () => Path;
         /**
          * @name Two.Points#getBoundingClientRect
          * @function
@@ -3545,22 +3997,42 @@ declare module "two.js/src/shapes/points" {
          * @description Recalculate the {@link Two.Points#length} value.
          */
         private _updateLength;
+        /**
+         * @name Two.Points#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.Points#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
     }
-    import { Shape } from "two.js/src/shape";
-    import { Gradient } from "two.js/src/effects/gradient";
-    import { Texture } from "two.js/src/effects/texture";
+    import { Path } from "src/path";
 }
-declare module "two.js/src/shapes/polygon" {
+declare module "src/shapes/polygon" {
     /**
      * @name Two.Polygon
      * @class
-
+     * @extends Two.Path
      * @param {Number} [x=0] - The x position of the polygon.
      * @param {Number} [y=0] - The y position of the polygon.
      * @param {Number} [radius=0] - The radius value of the polygon.
      * @param {Number} [sides=12] - The number of vertices used to construct the polygon.
      */
-    export class Polygon extends Path {
+    export class Polygon {
+        /**
+         * @name Two.Polygon.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.Polygon}.
+         */
+        static Properties: string[];
+        constructor(x: any, y: any, radius: any, sides: any);
         /**
          * @name Two.Polygon#_flagWidth
          * @private
@@ -3580,6 +4052,12 @@ declare module "two.js/src/shapes/polygon" {
          */
         private _flagSides;
         /**
+         * @name Two.Polygon#_radius
+         * @private
+         * @see {@link Two.Polygon#radius}
+         */
+        private _radius;
+        /**
          * @name Two.Polygon#_width
          * @private
          * @see {@link Two.Polygon#width}
@@ -3597,27 +4075,61 @@ declare module "two.js/src/shapes/polygon" {
          * @see {@link Two.Polygon#sides}
          */
         private _sides;
-        constructor(x?: number, y?: number, radius?: number, sides?: number);
         closed: boolean;
-        width: number;
-        height: number;
+        automatic: boolean;
+        radius: number;
         sides: number;
+        /**
+         * @name Two.Polygon#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.Polygon#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
+        /**
+         * @name Two.Polygon#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Polygon}
+         * @description Create a new instance of {@link Two.Polygon} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.Polygon;
+        /**
+         * @name Two.Polygon#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
     }
-    import { Path } from "two.js/src/path";
 }
-declare module "two.js/src/shapes/star" {
+declare module "src/shapes/star" {
     /**
      * @name Two.Star
      * @class
-
+     * @extends Two.Path
      * @param {Number} [x=0] - The x position of the star.
      * @param {Number} [y=0] - The y position of the star.
      * @param {Number} [innerRadius=0] - The inner radius value of the star.
      * @param {Number} [outerRadius=0] - The outer radius value of the star.
      * @param {Number} [sides=5] - The number of sides used to construct the star.
      */
-    export class Star extends Path {
-        constructor(ox?: number, oy?: number, ir?: number, or?: number, sides?: number);
+    export class Star {
+        /**
+         * @name Two.Star.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.Star}.
+         */
+        static Properties: string[];
+        constructor(x: any, y: any, innerRadius: any, outerRadius: any, sides: any, ...args: any[]);
         /**
          * @name Two.Star#_flagInnerRadius
          * @private
@@ -3655,22 +4167,53 @@ declare module "two.js/src/shapes/star" {
          */
         private _sides;
         closed: boolean;
+        automatic: boolean;
         innerRadius: number;
         outerRadius: number;
         sides: number;
+        /**
+         * @name Two.Star#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.Star#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
+        /**
+         * @name Two.Star#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Star}
+         * @description Create a new instance of {@link Two.Star} with the same properties of the current path.
+         */
+        clone(parent?: Two.Group): Two.Star;
+        /**
+         * @name Two.Star#toObject
+         * @function
+         * @returns {Object}
+         * @description Return a JSON compatible plain object that represents the path.
+         */
+        toObject(): any;
     }
-    import { Path } from "two.js/src/path";
 }
-declare module "two.js/src/renderers/svg" {
+declare module "src/renderers/svg" {
     /**
      * @name Two.SVGRenderer
      * @class
-
+     * @extends Two.Events
      * @param {Object} [parameters] - This object is inherited when constructing a new instance of {@link Two}.
      * @param {Element} [parameters.domElement] - The `<svg />` to draw to. If none given a new one will be constructed.
      * @description This class is used by {@link Two} when constructing with `type` of `Two.Types.svg` (the default type). It takes Two.js' scenegraph and renders it to a `<svg />`.
      */
-    export class Renderer extends Events {
+    export class Renderer {
         /**
          * @name Two.SVGRenderer.Utils
          * @property {Object} - A massive object filled with utility functions and properties to render Two.js objects to a `<svg />`.
@@ -3684,7 +4227,7 @@ declare module "two.js/src/renderers/svg" {
                 center: string;
                 right: string;
             };
-            createElement: (name: any, attrs: any) => SVGElement;
+            createElement: (name: any, attrs: any) => Element;
             setAttributes: (elem: any, attrs: any) => any;
             removeAttributes: (elem: any, attrs: any) => any;
             toString: (points: any, closed: any) => string;
@@ -3716,7 +4259,7 @@ declare module "two.js/src/renderers/svg" {
                 render: (domElement: any, silent: any) => any;
             };
         };
-        constructor(params?: any);
+        constructor(params: any);
         /**
          * @name Two.SVGRenderer#domElement
          * @property {Element} - The `<svg />` associated with the Two.js scene.
@@ -3724,14 +4267,14 @@ declare module "two.js/src/renderers/svg" {
         domElement: any;
         /**
          * @name Two.SVGRenderer#scene
-         * @property {Group} - The root group of the scenegraph.
+         * @property {Two.Group} - The root group of the scenegraph.
          */
         scene: Group;
         /**
          * @name Two.SVGRenderer#defs
          * @property {SvgDefintionsElement} - The `<defs />` to apply gradients, patterns, and bitmap imagery.
          */
-        defs: SVGDefsElement;
+        defs: Element;
         /**
          * @name Two.SVGRenderer#setSize
          * @function
@@ -3750,10 +4293,9 @@ declare module "two.js/src/renderers/svg" {
          */
         render(): Renderer;
     }
-    import { Events } from "two.js/src/events";
-    import { Group } from "two.js/src/group";
+    import { Group } from "src/group";
 }
-declare module "two.js/src/utils/shaders" {
+declare module "src/utils/shaders" {
     export namespace shaders {
         function create(gl: any, source: any, type: any): any;
         namespace types {
@@ -3774,11 +4316,11 @@ declare module "two.js/src/utils/shaders" {
         }
     }
 }
-declare module "two.js/src/renderers/webgl" {
+declare module "src/renderers/webgl" {
     /**
      * @name Two.WebGLRenderer
      * @class
-
+     * @extends Two.Events
      * @param {Object} [parameters] - This object is inherited when constructing a new instance of {@link Two}.
      * @param {Element} [parameters.domElement] - The `<canvas />` to draw to. If none given a new one will be constructed.
      * @param {HTMLCanvasElement} [parameters.offscreenElement] - The offscreen two dimensional `<canvas />` to render each element on WebGL texture updates.
@@ -3786,7 +4328,7 @@ declare module "two.js/src/renderers/webgl" {
      * @description This class is used by {@link Two} when constructing with `type` of `Two.Types.webgl`. It takes Two.js' scenegraph and renders it to a `<canvas />` through the WebGL api.
      * @see {@link https://www.khronos.org/registry/webgl/specs/latest/1.0/}
      */
-    export class Renderer extends Events {
+    export class Renderer {
         /**
          * @name Two.WebGLRenderer.Utils
          * @property {Object} - A massive object filled with utility functions and properties to render Two.js objects to a `<canvas />` through the WebGL API.
@@ -3840,15 +4382,15 @@ declare module "two.js/src/renderers/webgl" {
             };
             TextureRegistry: Registry;
         };
-        constructor(params?: any);
+        constructor(params: any);
         /**
          * @name Two.WebGLRenderer#domElement
          * @property {Element} - The `<canvas />` associated with the Two.js scene.
          */
-        domElement: HTMLCanvasElement;
+        domElement: any;
         /**
          * @name Two.WebGLRenderer#scene
-         * @property {Group} - The root group of the scenegraph.
+         * @property {Two.Group} - The root group of the scenegraph.
          */
         scene: Group;
         _renderer: {
@@ -3901,20 +4443,19 @@ declare module "two.js/src/renderers/webgl" {
          */
         render(): Renderer;
     }
-    import { Events } from "two.js/src/events";
-    import { Group } from "two.js/src/group";
-    import { Matrix } from "two.js/src/matrix";
-    import { Registry } from "two.js/src/registry";
+    import { Group } from "src/group";
+    import { Matrix } from "src/matrix";
+    import { Registry } from "src/registry";
 }
-declare module "two.js" {
+declare module "src/two" {
     /**
      * @name Two
      * @class
      * @global
-
+     * @extends Two.Events
      * @param {Object} [options]
      * @param {Boolean} [options.fullscreen=false] - Set to `true` to automatically make the stage adapt to the width and height of the parent document. This parameter overrides `width` and `height` parameters if set to `true`. This overrides `options.fitted` as well.
-     * @param {Boolean} [options.fitted=false] = Set to `true` to automatically make the stage adapt to the width and height of the parent element. This parameter overrides `width` and `height` parameters if set to `true`.
+     * @param {Boolean} [options.fitted=false] - Set to `true` to automatically make the stage adapt to the width and height of the parent element. This parameter overrides `width` and `height` parameters if set to `true`.
      * @param {Number} [options.width=640] - The width of the stage on construction. This can be set at a later time.
      * @param {Number} [options.height=480] - The height of the stage on construction. This can be set at a later time.
      * @param {String} [options.type=Two.Types.svg] - The type of renderer to setup drawing with. See {@link Two.Types} for available options.
@@ -4008,20 +4549,12 @@ declare module "two.js" {
         };
         /**
          * @name Two.Utils
-         * @property {Object} - A massive object filled with utility functions and properties.
+         * @property {Object} Utils - A massive object filled with utility functions and properties.
+         * @property {Object} Two.Utils.read - A collection of SVG parsing functions indexed by element name.
+         * @property {Function} Two.Utils.read.path - Parse SVG path element or `d` attribute string.
          */
         static Utils: any;
-        constructor(options?: {
-          fullscreen?: boolean,
-          fitted?: boolean,
-          autostart?: boolean,
-          width?: number,
-          height?: number,
-          type?: string,
-          domElement?: HTMLElement,
-          overdraw?: boolean,
-          smoothing?: boolean
-        });
+        constructor(options: any);
         /**
          * @private
          */
@@ -4045,14 +4578,14 @@ declare module "two.js" {
         type: string;
         /**
          * @name Two#renderer
-         * @property {(Two.SVGRenderer|CanvasRenderer|WebGLRenderer)} - The instantiated rendering class for the instance. For a list of possible rendering types check out Two.Types.
+         * @property {(Two.SVGRenderer|Two.CanvasRenderer|Two.WebGLRenderer)} - The instantiated rendering class for the instance. For a list of possible rendering types check out Two.Types.
          */
         renderer: any;
         /**
          * @name Two#scene
-         * @property {Group} - The base level {@link Two.Group} which houses all objects for the instance. Because it is a {@link Two.Group} transformations can be applied to it that will affect all objects in the instance. This is handy as a makeshift inverted camera.
+         * @property {Two.Group} - The base level {@link Two.Group} which houses all objects for the instance. Because it is a {@link Two.Group} transformations can be applied to it that will affect all objects in the instance. This is handy as a makeshift inverted camera.
          */
-        scene: Group;
+        scene: any;
         /**
          * @name Two#width
          * @property {Number} - The width of the instance's dom element.
@@ -4085,11 +4618,11 @@ declare module "two.js" {
          * @param {Element} elem - The DOM element to append the Two.js stage to.
          * @description Shorthand method to append your instance of Two.js to the `document`.
          */
-        appendTo(elem: HTMLElement): Two;
+        appendTo(elem: Element): Two;
         /**
          * @name Two#play
          * @function
-         * @fires Two.Events.Types.play event
+         * @fires play
          * @description Call to start an internal animation loop.
          * @nota-bene This function initiates a `requestAnimationFrame` loop.
          */
@@ -4097,7 +4630,7 @@ declare module "two.js" {
         /**
          * @name Two#pause
          * @function
-         * @fires Two.Events.Types.pause event
+         * @fires pause
          * @description Call to stop the internal animation loop for a specific instance of Two.js.
          */
         pause(): any;
@@ -4113,7 +4646,7 @@ declare module "two.js" {
         /**
          * @name Two#update
          * @function
-         * @fires Two.Events.Types.update event
+         * @fires update
          * @description Update positions and calculations in one pass before rendering. Then render to the canvas.
          * @nota-bene This function is called automatically if using {@link Two#play} or the `autostart` parameter in construction.
          */
@@ -4129,31 +4662,17 @@ declare module "two.js" {
         /**
          * @name Two#add
          * @function
-         * @param {TwoElement[]} [objects] - An array of Two.js objects. Alternatively can add objects as individual arguments.
+         * @param {(Two.Shape[]|...Two.Shape)} [objects] - An array of Two.js objects. Alternatively can add objects as individual arguments.
          * @description A shorthand method to add specific Two.js objects to the scene.
          */
-        add(objects: TwoElement): Two;
-        /**
-         * @name Two#add
-         * @function
-         * @param {...TwoElement} [args] - Alternatively pass each shape as an argument
-         * @description A shorthand method to add specific Two.js objects to the scene.
-         */
-        add(...args: TwoElement[]): Two;
+        add(objects: any, ...args: any[]): Two;
         /**
          * @name Two#remove
          * @function
-         * @param {TwoElement[]} [objects] - An array of Two.js objects.
+         * @param {(Two.Shape[]|...Two.Shape)} [objects] - An array of Two.js objects.
          * @description A shorthand method to remove specific Two.js objects from the scene.
          */
-        remove(objects: TwoElement): Two;
-        /**
-         * @name Two#remove
-         * @function
-         * @param {...TwoElement} [args] - Alternatively pass each shape as an argument
-         * @description A shorthand method to remove specific Two.js objects from the scene.
-         */
-        remove(...args: TwoElement[]): Two;
+        remove(objects: any, ...args: any[]): Two;
         /**
          * @name Two#clear
          * @function
@@ -4167,10 +4686,10 @@ declare module "two.js" {
          * @param {Number} y1
          * @param {Number} x2
          * @param {Number} y2
-         * @returns {Line}
+         * @returns {Two.Line}
          * @description Creates a Two.js line and adds it to the scene.
          */
-        makeLine(x1: number, y1: number, x2: number, y2: number): Line;
+        makeLine(x1: number, y1: number, x2: number, y2: number): typeof Line;
         /**
          * @name Two#makeArrow
          * @function
@@ -4178,10 +4697,10 @@ declare module "two.js" {
          * @param {Number} y1
          * @param {Number} x2
          * @param {Number} y2
-         * @returns {Path}
+         * @returns {Two.Path}
          * @description Creates a Two.js arrow and adds it to the scene.
          */
-        makeArrow(x1: number, y1: number, x2: number, y2: number, size: number): Path;
+        makeArrow(x1: number, y1: number, x2: number, y2: number, size: any): typeof Path;
         /**
          * @name Two#makeRectangle
          * @function
@@ -4189,10 +4708,10 @@ declare module "two.js" {
          * @param {Number} y
          * @param {Number} width
          * @param {Number} height
-         * @returns {Rectangle}
+         * @returns {Two.Rectangle}
          * @description Creates a Two.js rectangle and adds it to the scene.
          */
-        makeRectangle(x: number, y: number, width: number, height: number): Rectangle;
+        makeRectangle(x: number, y: number, width: number, height: number): typeof Rectangle;
         /**
          * @name Two#makeRoundedRectangle
          * @function
@@ -4201,10 +4720,10 @@ declare module "two.js" {
          * @param {Number} width
          * @param {Number} height
          * @param {Number} sides
-         * @returns {Rectangle}
+         * @returns {Two.Rectangle}
          * @description Creates a Two.js rounded rectangle and adds it to the scene.
          */
-        makeRoundedRectangle(x: number, y: number, width: number, height: number, sides: number): Rectangle;
+        makeRoundedRectangle(x: number, y: number, width: number, height: number, sides: number): typeof Rectangle;
         /**
          * @name Two#makeCircle
          * @function
@@ -4212,10 +4731,10 @@ declare module "two.js" {
          * @param {Number} y
          * @param {Number} radius
          * @param {Number} [resolution=4]
-         * @returns {Circle}
+         * @returns {Two.Circle}
          * @description Creates a Two.js circle and adds it to the scene.
          */
-        makeCircle(x: number, y: number, radius: number, resolution?: number): Circle;
+        makeCircle(x: number, y: number, radius: number, resolution?: number): typeof Circle;
         /**
          * @name Two#makeEllipse
          * @function
@@ -4224,10 +4743,10 @@ declare module "two.js" {
          * @param {Number} rx
          * @param {Number} ry
          * @param {Number} [resolution=4]
-         * @returns {Ellipse}
+         * @returns {Two.Ellipse}
          * @description Creates a Two.js ellipse and adds it to the scene.
          */
-        makeEllipse(x: number, y: number, rx: number, ry: number, resolution?: number): Ellipse;
+        makeEllipse(x: number, y: number, rx: number, ry: number, resolution?: number): typeof Ellipse;
         /**
          * @name Two#makeStar
          * @function
@@ -4236,28 +4755,20 @@ declare module "two.js" {
          * @param {Number} outerRadius
          * @param {Number} innerRadius
          * @param {Number} sides
-         * @returns {Star}
+         * @returns {Two.Star}
          * @description Creates a Two.js star and adds it to the scene.
          */
-        makeStar(x: any, y: any, outerRadius: number, innerRadius: number, sides: number): Star;
+        makeStar(x: number, y: number, outerRadius: number, innerRadius: number, sides: number): typeof Star;
         /**
          * @name Two#makeCurve
          * @function
-         * @param {Anchor[]} [points] - An array of {@link Two.Anchor} points.
-         * @returns {Path} - Where `path.curved` is set to `true`.
+         * @param {Two.Anchor[]} [points] - An array of {@link Two.Anchor} points.
+         * @param {...Number} - Alternatively you can pass alternating `x` / `y` coordinate values as individual arguments. These will be combined into {@link Two.Anchor}s for use in the path.
+         * @returns {Two.Path} - Where `path.curved` is set to `true`.
          * @description Creates a Two.js path that is curved and adds it to the scene.
          * @nota-bene In either case of passing an array or passing numbered arguments the last argument is an optional `Boolean` that defines whether the path should be open or closed.
          */
-        makeCurve(points?: Anchor[]): Path;
-        /**
-         * @name Two#makeCurve
-         * @function
-         * @param {...Number} [args] - Alternatively you can pass alternating `x` / `y` coordinate values as individual arguments. These will be combined into {@link Two.Anchor}s for use in the path.
-         * @returns {Path} - Where `path.curved` is set to `true`.
-         * @description Creates a Two.js path that is curved and adds it to the scene.
-         * @nota-bene In either case of passing an array or passing numbered arguments the last argument is an optional `Boolean` that defines whether the path should be open or closed.
-         */
-        makeCurve(...args: number[]): Path;
+        makeCurve(points?: (typeof Anchor)[], ...args: any[]): typeof Path;
         /**
          * @name Two#makePolygon
          * @function
@@ -4265,10 +4776,10 @@ declare module "two.js" {
          * @param {Number} y
          * @param {Number} radius
          * @param {Number} sides
-         * @returns {Polygon}
+         * @returns {Two.Polygon}
          * @description Creates a Two.js polygon and adds it to the scene.
          */
-        makePolygon(x: number, y: number, radius: number, sides: number): Polygon;
+        makePolygon(x: number, y: number, radius: number, sides: number): typeof Polygon;
         /**
          * @name Two#makeArcSegment
          * @function
@@ -4279,43 +4790,28 @@ declare module "two.js" {
          * @param {Number} startAngle
          * @param {Number} endAngle
          * @param {Number} [resolution=Two.Resolution] - The number of vertices that should comprise the arc segment.
-         * @returns {ArcSegment}
+         * @returns {Two.ArcSegment}
          */
-        makeArcSegment(x: number, y: number, innerRadius: number, outerRadius: number, startAngle: number, endAngle: number, resolution?: number): ArcSegment;
+        makeArcSegment(x: number, y: number, innerRadius: number, outerRadius: number, startAngle: number, endAngle: number, resolution?: number): typeof ArcSegment;
         /**
          * @name Two#makePoints
          * @function
-         * @param {Vector[]} [points] - An array of {@link Two.Vector} points
-         * @returns {Points}
+         * @param {Two.Vector[]} [points] - An array of {@link Two.Vector} points
+         * @param {...Number} - Alternatively you can pass alternating `x` / `y` coordinate values as individual agrguments. These will be combined into {@link Two.Vector}s for use in the points object.
+         * @returns {Two.Points}
          * @description Creates a Two.js points object and adds it to the current scene.
          */
-        makePoints(points?: Vector[]): Points;
-        /**
-         * @name Two#makePoints
-         * @function
-         * @param {...Number} [args] - Alternatively you can pass alternating `x` / `y` coordinate values as individual agrguments. These will be combined into {@link Two.Vector}s for use in the points object.
-         * @returns {Points}
-         * @description Creates a Two.js points object and adds it to the current scene.
-         */
-        makePoints(...args: number[]): Points;
+        makePoints(p: any, ...args: any[]): typeof Points;
         /**
          * @name Two#makePath
          * @function
-         * @param {Anchor[]} [points] - An array of {@link Two.Anchor} points
-         * @returns {Path}
+         * @param {Two.Anchor[]} [points] - An array of {@link Two.Anchor} points
+         * @param {...Number} - Alternatively you can pass alternating `x` / `y` coordinate values as individual arguments. These will be combined into {@link Two.Anchor}s for use in the path.
+         * @returns {Two.Path}
          * @description Creates a Two.js path and adds it to the scene.
          * @nota-bene In either case of passing an array or passing numbered arguments the last argument is an optional `Boolean` that defines whether the path should be open or closed.
          */
-        makePath(points?: Anchor[]): Path;
-        /**
-         * @name Two#makePath
-         * @function
-         * @param {...Number} [args] - Alternatively you can pass alternating `x` / `y` coordinate values as individual arguments. These will be combined into {@link Two.Anchor}s for use in the path.
-         * @returns {Path}
-         * @description Creates a Two.js path and adds it to the scene.
-         * @nota-bene In either case of passing an array or passing numbered arguments the last argument is an optional `Boolean` that defines whether the path should be open or closed.
-         */
-        makePath(...args: number[]): Path;
+        makePath(p: any, ...args: any[]): typeof Path;
         /**
          * @name Two#makeText
          * @function
@@ -4323,10 +4819,10 @@ declare module "two.js" {
          * @param {Number} x
          * @param {Number} y
          * @param {Object} [styles] - An object to describe any of the {@link Two.Text.Properties} including `fill`, `stroke`, `linewidth`, `family`, `alignment`, `leading`, `opacity`, etc..
-         * @returns {Text}
+         * @returns {Two.Text}
          * @description Creates a Two.js text object and adds it to the scene.
          */
-        makeText(message: string, x: number, y: number, styles?: any): Text;
+        makeText(message: string, x: number, y: number, styles?: any): typeof Text;
         /**
          * @name Two#makeLinearGradient
          * @function
@@ -4334,133 +4830,184 @@ declare module "two.js" {
          * @param {Number} y1
          * @param {Number} x2
          * @param {Number} y2
-         * @param {...Stop} args - Any number of color stops sometimes reffered to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
-         * @returns {LinearGradient}
-         * @description Creates a Two.js linear gradient and ads it to the scene. In the case of an effect it's added to an invisible "definitions" group.
+         * @param {...Two.Stop} args - Any number of color stops sometimes referred to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
+         * @returns {Two.LinearGradient}
+         * @description Creates a Two.js linear gradient and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
          */
-        makeLinearGradient(x1: number, y1: number, x2: number, y2: number, ...args: Stop[]): LinearGradient;
+        makeLinearGradient(x1: number, y1: number, x2: number, y2: number, ...args: any[]): typeof LinearGradient;
         /**
          * @name Two#makeRadialGradient
          * @function
          * @param {Number} x1
          * @param {Number} y1
          * @param {Number} radius
-         * @param {...Stop} args - Any number of color stops sometimes reffered to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
-         * @returns {RadialGradient}
-         * @description Creates a Two.js linear-gradient object and ads it to the scene. In the case of an effect it's added to an invisible "definitions" group.
+         * @param {...Two.Stop} args - Any number of color stops sometimes referred to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
+         * @returns {Two.RadialGradient}
+         * @description Creates a Two.js linear-gradient object and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
          */
-        makeRadialGradient(x1: number, y1: number, radius: number, ...args: Stop[]): RadialGradient;
+        makeRadialGradient(x1: number, y1: number, radius: number, ...args: any[]): typeof RadialGradient;
         /**
          * @name Two#makeSprite
          * @function
-         * @param {(String|Texture)} pathOrTexture - The URL path to an image or an already created {@link Two.Texture}.
+         * @param {(String|Two.Texture)} pathOrTexture - The URL path to an image or an already created {@link Two.Texture}.
          * @param {Number} x
          * @param {Number} y
          * @param {Number} [columns=1]
          * @param {Number} [rows=1]
          * @param {Number} [frameRate=0]
          * @param {Boolean} [autostart=false]
-         * @returns {Sprite}
+         * @returns {Two.Sprite}
          * @description Creates a Two.js sprite object and adds it to the scene. Sprites can be used for still images as well as animations.
          */
-        makeSprite(pathOrTexture: any, x: number, y: number, columns?: number, rows?: number, frameRate?: number, autostart?: boolean): Sprite;
+        makeSprite(pathOrTexture: (string | typeof Texture), x: number, y: number, columns?: number, rows?: number, frameRate?: number, autostart?: boolean): typeof Sprite;
         /**
          * @name Two#makeImageSequence
          * @function
-         * @param {(String[]|Texture[])} pathsOrTextures - An array of paths or of {@link Two.Textures}.
+         * @param {(String[]|Two.Texture[])} pathsOrTextures - An array of paths or of {@link Two.Textures}.
          * @param {Number} x
          * @param {Number} y
          * @param {Number} [frameRate=0]
          * @param {Boolean} [autostart=false]
-         * @returns {ImageSequence}
+         * @returns {Two.ImageSequence}
          * @description Creates a Two.js image sequence object and adds it to the scene.
          */
-        makeImageSequence(pathsOrTextures: any, x: number, y: number, frameRate?: number, autostart?: boolean): ImageSequence;
+        makeImageSequence(pathsOrTextures: (string[] | (typeof Texture)[]), x: number, y: number, frameRate?: number, autostart?: boolean): typeof ImageSequence;
         /**
          * @name Two#makeTexture
          * @function
          * @param {(String|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement)} [pathOrSource] - The URL path to an image or a DOM image-like element.
          * @param {Function} [callback] - Function to be invoked when the image is loaded.
-         * @returns {Texture}
+         * @returns {Two.Texture}
          * @description Creates a Two.js texture object.
          */
-        makeTexture(pathOrSource: any, callback?: Function): Texture;
+        makeTexture(pathOrSource?: (string | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement), callback?: Function): typeof Texture;
         /**
          * @name Two#makeGroup
          * @function
-         * @param {TwoElement[]} [objects] - Two.js objects to be added to the group in the form of an array or as individual arguments.
-         * @returns {Group}
+         * @param {(Two.Shape[]|...Two.Shape)} [objects] - Two.js objects to be added to the group in the form of an array or as individual arguments.
+         * @returns {Two.Group}
          * @description Creates a Two.js group object and adds it to the scene.
          */
-        makeGroup(objects?: TwoElement[]): Group;
-        /**
-         * @name Two#makeGroup
-         * @function
-         * @param {...TwoElement} [args] - Alternatively pass each element as an argument
-         * @returns {Group}
-         * @description Creates a Two.js group object and adds it to the scene.
-         */
-        makeGroup(...args: TwoElement[]): Group;
+        makeGroup(objects: any, ...args: any[]): typeof Group;
         /**
          * @name Two#interpret
          * @function
          * @param {SVGElement} svg - The SVG node to be parsed.
          * @param {Boolean} shallow - Don't create a top-most group but append all content directly.
          * @param {Boolean} [add=true] – Automatically add the reconstructed SVG node to scene.
-         * @returns {Group}
+         * @returns {Two.Group}
          * @description Interpret an SVG Node and add it to this instance's scene. The distinction should be made that this doesn't `import` svg's, it solely interprets them into something compatible for Two.js - this is slightly different than a direct transcription.
          */
-        interpret(svg: SVGElement, shallow?: boolean, add?: boolean): Group;
+        interpret(svg: SVGElement, shallow: boolean, add?: boolean): typeof Group;
         /**
          * @name Two#load
          * @function
          * @param {String|SVGElement} pathOrSVGContent - The URL path of an SVG file or an SVG document as text.
          * @param {Function} callback - Function to call once loading has completed.
-         * @returns {Group}
+         * @returns {Two.Group}
          * @description Load an SVG file or SVG text and interpret it into Two.js legible objects.
          */
-        load(pathOrSVGContent: any, callback: Function): Group;
+        load(pathOrSVGContent: string | SVGElement, callback: Function): typeof Group;
     }
-    import { Line } from "two.js/src/shapes/line";
-    import { Path } from "two.js/src/path";
-    import { Rectangle } from "two.js/src/shapes/rectangle";
-    import { Circle } from "two.js/src/shapes/circle";
-    import { Ellipse } from "two.js/src/shapes/ellipse";
-    import { Star } from "two.js/src/shapes/star";
-    import { Polygon } from "two.js/src/shapes/polygon";
-    import { ArcSegment } from "two.js/src/shapes/arc-segment";
-    import { Points } from "two.js/src/shapes/points";
-    import { Text } from "two.js/src/text";
-    import { LinearGradient } from "two.js/src/effects/linear-gradient";
-    import { RadialGradient } from "two.js/src/effects/radial-gradient";
-    import { Sprite } from "two.js/src/effects/sprite";
-    import { ImageSequence } from "two.js/src/effects/image-sequence";
-    import { Texture } from "two.js/src/effects/texture";
-    import { Group } from "two.js/src/group";
-    import { Anchor } from "two.js/src/anchor";
-    import { Collection } from "two.js/src/collection";
-    import { Events } from "two.js/src/events";
-    import { Matrix } from "two.js/src/matrix";
-    import { Registry } from "two.js/src/registry";
-    import { Shape } from "two.js/src/shape";
-    import { Vector } from "two.js/src/vector";
-    import { Gradient } from "two.js/src/effects/gradient";
-    import { Stop } from "two.js/src/effects/stop";
-    import { RoundedRectangle } from "two.js/src/shapes/rounded-rectangle";
-    import { Renderer as CanvasRenderer } from "two.js/src/renderers/canvas";
-    import { Renderer as SVGRenderer } from "two.js/src/renderers/svg";
-    import { Renderer as WebGLRenderer } from "two.js/src/renderers/webgl";
-    import { Element as TwoElement } from 'two.js/src/element'
+    import { Line } from "src/shapes/line";
+    import { Path } from "src/path";
+    import { Rectangle } from "src/shapes/rectangle";
+    import { Circle } from "src/shapes/circle";
+    import { Ellipse } from "src/shapes/ellipse";
+    import { Star } from "src/shapes/star";
+    import { Anchor } from "src/anchor";
+    import { Polygon } from "src/shapes/polygon";
+    import { ArcSegment } from "src/shapes/arc-segment";
+    import { Points } from "src/shapes/points";
+    import { Text } from "src/text";
+    import { LinearGradient } from "src/effects/linear-gradient";
+    import { RadialGradient } from "src/effects/radial-gradient";
+    import { Texture } from "src/effects/texture";
+    import { Sprite } from "src/effects/sprite";
+    import { ImageSequence } from "src/effects/image-sequence";
+    import { Group } from "src/group";
+    import { Collection } from "src/collection";
+    import { Events } from "src/events";
+    import { Matrix } from "src/matrix";
+    import { Registry } from "src/registry";
+    import { Shape } from "src/shape";
+    import { Vector } from "src/vector";
+    import { Gradient } from "src/effects/gradient";
+    import { Stop } from "src/effects/stop";
+    import { RoundedRectangle } from "src/shapes/rounded-rectangle";
+    import { Renderer as CanvasRenderer } from "src/renderers/canvas";
+    import { Renderer as SVGRenderer } from "src/renderers/svg";
+    import { Renderer as WebGLRenderer } from "src/renderers/webgl";
 }
-declare module "two.js/extras/jsm/zui" {
+declare module "extras/jsm/arc" {
+    /**
+     * @name Two.Arc
+     * @class
+     * @extends Two.Path
+     * @param {Number} [x=0] - The x position of the arc.
+     * @param {Number} [y=0] - The y position of the arc.
+     * @param {Number} [width=0] - The width, horizontal diameter, of the arc.
+     * @param {Number} [height=0] - The height, vertical diameter, of the arc.
+     * @param {Number} [startAngle=0] - The starting angle of the arc in radians.
+     * @param {Number} [endAngle=6.283] - The ending angle of the arc in radians.
+     * @param {Number} [resolution=4] - The number of vertices used to construct the circle.
+     */
+    export class Arc {
+        /**
+         * @name Two.Arc.Properties
+         * @property {String[]} - A list of properties that are on every {@link Two.Arc}.
+         */
+        static Properties: string[];
+        constructor(x: any, y: any, width: any, height: any, startAngle: any, endAngle: any, resolution: any);
+        _flagWidth: boolean;
+        _flagHeight: boolean;
+        _flagStartAngle: boolean;
+        _flagEndAngle: boolean;
+        _width: number;
+        _height: number;
+        _startAngle: number;
+        _endAngle: number;
+        curved: boolean;
+        width: number;
+        height: number;
+        startAngle: number;
+        endAngle: number;
+        /**
+         * @name Two.Arc#_update
+         * @function
+         * @private
+         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
+         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
+         * @nota-bene Try not to call this method more than once a frame.
+         */
+        private _update;
+        /**
+         * @name Two.Arc#flagReset
+         * @function
+         * @private
+         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
+         */
+        private flagReset;
+        /**
+         * @name Two.Arc#clone
+         * @function
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.ArcSegment}
+         * @description Create a new instance of {@link Two.ArcSegment} with the same properties of the current path.
+         */
+        clone(): Two.ArcSegment;
+    }
+}
+declare module "extras/jsm/zui" {
     /**
      * @name Two.ZUI
      * @class
-     * @param {Group} group - The scene or group to
+     * @param {Two.Group} group - The scene or group to
      * @param {HTMLElement} [domElement=document.body] - The HTML Element to attach event listeners to.
+     * @description {@link Two.ZUI} is an extra class to turn your Two.js scene into a Google Maps or Adobe Illustrator style interface. See {@link https://codepen.io/jonobr1/pen/PobMKwb} for example usage.
      */
     export class ZUI {
-        static Surface: Surface;
+        static Surface: typeof Surface;
         static Clamp(v: any, min: any, max: any): number;
         static Limit: {
             min: number;
@@ -4470,7 +5017,7 @@ declare module "two.js/extras/jsm/zui" {
         static TranslateMatrix(m: any, x: any, y: any): any;
         static PositionToScale(pos: any): number;
         static ScaleToPosition(scale: any): number;
-        constructor(group?: Group, domElement?: HTMLElement);
+        constructor(group: any, domElement: any);
         limits: {
             scale: {};
             x: {};
@@ -4485,21 +5032,88 @@ declare module "two.js/extras/jsm/zui" {
         surfaceMatrix: Matrix;
         surfaces: any[];
         add(surface: any): ZUI;
-        addLimits(min: number, max: number, type?: number): ZUI;
-        clientToSurface(v?: { x?: number, y?: number, z?: number }): { x: number, y: number, z: number };
-        surfaceToClient(v?: { x?: number, y?: number, z?: number }): { x: number, y: number, z: number };
-        zoomBy(byF: any, clientX: any, clientY: any): ZUI;
-        zoomSet(zoom: any, clientX: any, clientY: any): ZUI;
+        /**
+         * @name Two.ZUI#addLimits
+         * @function
+         * @param {Number} [min=-Infinity] - The minimum scale the ZUI can zoom out to.
+         * @param {Number} [max=Infinity] - The maximum scale teh ZUI can zoom in to.
+         */
+        addLimits(min?: number, max?: number): ZUI;
+        /**
+         * @name Two.ZUI#clientToSurface
+         * @function
+         * @param {Two.Vector} a
+         * @description Convert an x, y coordinate in the user’s space to the object's projected space. Optionally pass a z property on the object to apply depth.
+         * @returns {Object} - An object with x, y, and z components
+         * @overloaded
+         */
+        /**
+         * @name Two.ZUI#clientToSurface
+         * @param {Number} [a=0] - The x component of position to be transformed.
+         * @param {Number} [b=0] - The y component of position to be transformed.
+         * @param {Number} [c=1] - The optional z component of position to be transformed.
+         * @description Convert an x, y coordinate in the user’s space to the object's projected space. Optionally pass a z property on the object to apply depth.
+         * @returns {Object} - An object with x, y, and z components
+         * @overloaded
+         */
+        clientToSurface(a?: number, b?: number, c?: number, ...args: any[]): any;
+        /**
+         * @name Two.ZUI#surfaceToClient
+         * @function
+         * @param {Two.Vector} a
+         * @description Convert an x, y coordinate in projected space to the user’s space. Optionally pass a z property on the object to apply depth.
+         * @returns {Object} - An object with x, y, and z components
+         * @overloaded
+         */
+        /**
+         * @name Two.ZUI#surfaceToClient
+         * @param {Number} [a=0] - The x component of position to be transformed.
+         * @param {Number} [b=0] - The y component of position to be transformed.
+         * @param {Number} [c=1] - The optional z component of position to be transformed.
+         * @description Convert an x, y coordinate in projected space to the user’s space. Optionally pass a z property on the object to apply depth.
+         * @returns {Object} - An object with x, y, and z components
+         * @overloaded
+         */
+        surfaceToClient(a?: number, b?: number, c?: number, ...args: any[]): any;
+        /**
+         * @name Two.ZUI#zoomBy
+         * @function
+         * @param {Number} byF - The factor to scale by.
+         * @param {Number} clientX - The x position of the user's input.
+         * @param {Number} clientY - The y position of the user's input.
+         * @description A function to zoom by an incremental amount and a position. Typically used for pinch-and-zoom or mousewheel effects.
+         */
+        zoomBy(byF: number, clientX: number, clientY: number): ZUI;
+        /**
+         * @name Two.ZUI#zoomSet
+         * @function
+         * @param {Number} zoom - The level of the zoom.
+         * @param {Number} clientX - The x position of the user's input.
+         * @param {Number} clientY - The y position of the user's input.
+         * @description A function to set the zoom amount and the origin position. This is used internally by {@Two.ZUI#zoomBy}.
+         */
+        zoomSet(zoom: number, clientX: number, clientY: number): ZUI;
         zoom: number;
         scale: any;
-        translateSurface(x: any, y: any): ZUI;
+        /**
+         * @name Two.ZUI#translateSurface
+         * @function
+         * @param {Number} x - The x amount to pan.
+         * @param {Number} y - The y amount to pan.
+         * @description Set the position of the ZUI by an incremental translation amount.
+         */
+        translateSurface(x: number, y: number): ZUI;
         updateOffset(): ZUI;
         updateSurface(): ZUI;
+        /**
+         * @name Two.ZUI#reset
+         * @function
+         * @description Reset the zoom and scale factors to their original instantiated state.
+         */
         reset(): ZUI;
         fitToLimits(s: any): number;
     }
-    import { Matrix } from "two.js/src/matrix";
-    import { Group } from "two.js/src/group";
+    import { Matrix } from "src/matrix";
     class Surface {
         constructor(object: any);
         object: any;
@@ -4511,4 +5125,5 @@ declare module "two.js/extras/jsm/zui" {
         max: any;
         apply(px: any, py: any, s: any): Surface;
     }
+    export {};
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,4 @@
-declare module "src/utils/path-commands" {
+declare module "two.js/src/utils/path-commands" {
     export namespace Commands {
         const move: string;
         const line: string;
@@ -7,27 +7,28 @@ declare module "src/utils/path-commands" {
         const close: string;
     }
 }
-declare module "src/utils/root" {
+declare module "two.js/src/utils/root" {
     export let root: any;
 }
-declare module "src/utils/math" {
+declare module "two.js/src/utils/math" {
     /**
      * @name Two.Utils.decomposeMatrix
      * @function
-     * @param {Two.Matrix} matrix - The matrix to decompose.
+     * @param {Matrix} matrix - The matrix to decompose.
      * @returns {Object} An object containing relevant skew values.
      * @description Decompose a 2D 3x3 Matrix to find the skew.
      */
-    export function decomposeMatrix(matrix: Two.Matrix, b: any, c: any, d: any, e: any, f: any, ...args: any[]): any;
+    export function decomposeMatrix(matrix: Matrix): any;
+    export function decomposeMatrix(a: number, b: number, c: number, d: number, e: number, f: number): any;
     /**
      * @name Two.Utils.getComputedMatrix
      * @function
-     * @param {Two.Shape} object - The Two.js object that has a matrix property to calculate from.
-     * @param {Two.Matrix} [matrix] - The matrix to apply calculated transformations to if available.
-     * @returns {Two.Matrix} The computed matrix of a nested object. If no `matrix` was passed in arguments then a `new Two.Matrix` is returned.
+     * @param {Shape} object - The Two.js object that has a matrix property to calculate from.
+     * @param {Matrix} [matrix] - The matrix to apply calculated transformations to if available.
+     * @returns {Matrix} The computed matrix of a nested object. If no `matrix` was passed in arguments then a `new Two.Matrix` is returned.
      * @description Method to get the world space transformation of a given object in a Two.js scene.
      */
-    export function getComputedMatrix(object: Two.Shape, matrix?: Two.Matrix): Two.Matrix;
+    export function getComputedMatrix(object: Shape, matrix?: Matrix): Matrix;
     export function getPoT(value: any): number;
     export function setMatrix(matrix: any): void;
     /**
@@ -61,8 +62,10 @@ declare module "src/utils/math" {
     export function toFixed(v: number): number;
     export const TWO_PI: number;
     export const HALF_PI: number;
+    import { Matrix } from "two.js/src/matrix";
+    import { Shape } from "two.js/src/shape";
 }
-declare module "src/events" {
+declare module "two.js/src/events" {
     /**
      * @name Two.Events
      * @class
@@ -141,102 +144,79 @@ declare module "src/events" {
         ignore(obj: any, name: any, handler: any): Events;
     }
 }
-declare module "src/vector" {
+declare module "two.js/src/vector" {
     /**
      * @name Two.Vector
      * @class
-     * @extends Two.Events
+
      * @param {Number} [x=0] - Any number to represent the horizontal x-component of the vector.
      * @param {Number} [y=0] - Any number to represent the vertical y-component of the vector.
      * @description A class to store x / y component vector data. In addition to storing data `Two.Vector` has suped up methods for commonplace mathematical operations.
      */
-    export class Vector {
+    export class Vector extends Events {
         /**
          * @name Two.Vector.zero
          * @readonly
-         * @property {Two.Vector} - Handy reference to a vector with component values 0, 0 at all times.
+         * @property {Vector} - Handy reference to a vector with component values 0, 0 at all times.
          */
         static readonly zero: Vector;
         /**
-         * @name Two.Vector.left
-         * @readonly
-         * @property {Two.Vector} - Handy reference to a vector with component values -1, 0 at all times.
-         */
-        static readonly left: Vector;
-        /**
-         * @name Two.Vector.right
-         * @readonly
-         * @property {Two.Vector} - Handy reference to a vector with component values 1, 0 at all times.
-         */
-        static readonly right: Vector;
-        /**
-         * @name Two.Vector.up
-         * @readonly
-         * @property {Two.Vector} - Handy reference to a vector with component values 0, -1 at all times.
-         */
-        static readonly up: Vector;
-        /**
-         * @name Two.Vector.down
-         * @readonly
-         * @property {Two.Vector} - Handy reference to a vector with component values 0, 1 at all times.
-         */
-        static readonly down: Vector;
-        /**
          * @name Two.Vector.add
          * @function
-         * @param {Two.Vector} v1
-         * @param {Two.Vector} v2
-         * @returns {Two.Vector}
+         * @param {Vector} v1
+         * @param {Vector} v2
+         * @returns {Vector}
          * @description Add two vectors together.
          */
-        static add(v1: Two.Vector, v2: Two.Vector): Two.Vector;
+        static add(v1: Vector, v2: Vector): Vector;
         /**
          * @name Two.Vector.sub
          * @function
-         * @param {Two.Vector} v1
-         * @param {Two.Vector} v2
-         * @returns {Two.Vector}
+         * @param {Vector} v1
+         * @param {Vector} v2
+         * @returns {Vector}
          * @description Subtract two vectors: `v2` from `v1`.
          */
-        static sub(v1: Two.Vector, v2: Two.Vector): Two.Vector;
+        static sub(v1: Vector, v2: Vector): Vector;
         /**
          * @name Two.Vector.subtract
          * @function
          * @description Alias for {@link Two.Vector.sub}.
          */
-        static subtract(v1: any, v2: any): Two.Vector;
+        static subtract(v1: Vector, v2: Vector): Vector;
         /**
          * @name Two.Vector.ratioBetween
          * @function
-         * @param {Two.Vector} v1
-         * @param {Two.Vector} v2
+         * @param {Vector} v1
+         * @param {Vector} v2
          * @returns {Number} The ratio betwen two points `v1` and `v2`.
          */
-        static ratioBetween(v1: Two.Vector, v2: Two.Vector): number;
+        static ratioBetween(v1: Vector, v2: Vector): number;
         /**
          * @name Two.Vector.angleBetween
          * @function
-         * @param {Two.Vector} v1
-         * @param {Two.Vector} v2
+         * @param {Vector} v1
+         * @param {Vector} v2
          * @returns {Number} The angle between points `v1` and `v2`.
          */
-        static angleBetween(v1: Two.Vector, v2: Two.Vector, ...args: any[]): number;
+        static angleBetween(v1: Vector, v2: Vector): number;
+        static angleBetween(x1: number, y1: number, x2: number, y2: number): number;
         /**
          * @name Two.Vector.distanceBetween
          * @function
-         * @param {Two.Vector} v1
-         * @param {Two.Vector} v2
+         * @param {Vector} v1
+         * @param {Vector} v2
          * @returns {Number} The distance between points `v1` and `v2`. Distance is always positive.
          */
-        static distanceBetween(v1: Two.Vector, v2: Two.Vector): number;
+        static distanceBetween(v1: Vector, v2: Vector): number;
         /**
          * @name Two.Vector.distanceBetweenSquared
          * @function
-         * @param {Two.Vector} v1
-         * @param {Two.Vector} v2
+         * @param {Vector} v1
+         * @param {Vector} v2
          * @returns {Number} The squared distance between points `v1` and `v2`.
          */
-        static distanceBetweenSquared(v1: Two.Vector, v2: Two.Vector): number;
+        static distanceBetweenSquared(v1: Vector, v2: Vector): number;
         constructor(x?: number, y?: number);
         /**
          * @name Two.Vector#_x
@@ -260,14 +240,14 @@ declare module "src/vector" {
          * @type {Number}
          */
         y: number;
-        set(x: any, y: any): Vector;
+        set(x: number, y: number): Vector;
         /**
          * @name Two.Vector#copy
          * @function
-         * @param {Two.Vector} v
+         * @param {Vector} v
          * @description Copy the x / y components of another object `v`.
          */
-        copy(v: Two.Vector): Vector;
+        copy(v: Vector): Vector;
         /**
          * @name Two.Vector#clear
          * @function
@@ -283,10 +263,11 @@ declare module "src/vector" {
         /**
          * @name Two.Vector#add
          * @function
-         * @param {Two.Vector} v
+         * @param {Vector} v
          * @description Add an object with x / y component values to the instance.
          * @overloaded
          */
+        add(v: Vector): Vector;
         /**
          * @name Two.Vector#add
          * @function
@@ -294,6 +275,7 @@ declare module "src/vector" {
          * @description Add the **same** number to both x / y component values of the instance.
          * @overloaded
          */
+        add(v: number): Vector;
         /**
          * @name Two.Vector#add
          * @function
@@ -302,20 +284,23 @@ declare module "src/vector" {
          * @description Add `x` / `y` values to their respective component value on the instance.
          * @overloaded
          */
-        add(x: number, y: number, ...args: any[]): Vector;
+        add(x: number, y: number): Vector;
         /**
          * @name Two.Vector#addSelf
          * @function
          * @description Alias for {@link Two.Vector.add}.
          */
-        addSelf(v: any, ...args: any[]): any;
+        addSelf(x: number, y: number): Vector;
+        addSelf(v: Vector): Vector;
+        addSelf(v: number): Vector;
         /**
          * @name Two.Vector#sub
          * @function
-         * @param {Two.Vector} v
+         * @param {Vector} v
          * @description Subtract an object with x / y component values to the instance.
          * @overloaded
          */
+        sub(v: Vector): Vector;
         /**
          * @name Two.Vector#sub
          * @function
@@ -323,6 +308,7 @@ declare module "src/vector" {
          * @description Subtract the **same** number to both x / y component values of the instance.
          * @overloaded
          */
+        sub(v: number): Vector;
         /**
          * @name Two.Vector#sub
          * @function
@@ -331,32 +317,39 @@ declare module "src/vector" {
          * @description Subtract `x` / `y` values to their respective component value on the instance.
          * @overloaded
          */
-        sub(x: number, y: number, ...args: any[]): Vector;
+        sub(x: number, y: number): Vector;
         /**
          * @name Two.Vector#subtract
          * @function
          * @description Alias for {@link Two.Vector.sub}.
          */
-        subtract(...args: any[]): any;
+        subtract(x: number, y: number): Vector;
+        subtract(v: number): Vector;
+        subtract(v: Vector): Vector;
         /**
          * @name Two.Vector#subSelf
          * @function
          * @description Alias for {@link Two.Vector.sub}.
          */
-        subSelf(v: any, ...args: any[]): any;
+        subSelf(x: number, y: number): Vector;
+        subSelf(v: number): Vector;
+        subSelf(v: Vector): Vector;
         /**
          * @name Two.Vector#subtractSelf
          * @function
          * @description Alias for {@link Two.Vector.sub}.
          */
-        subtractSelf(v: any, ...args: any[]): any;
+        subtractSelft(x: number, y: number): Vector;
+        subtractSelft(v: number): Vector;
+        subtractSelft(v: Vector): Vector;
         /**
          * @name Two.Vector#multiply
          * @function
-         * @param {Two.Vector} v
+         * @param {Vector} v
          * @description Multiply an object with x / y component values to the instance.
          * @overloaded
          */
+        multiply(v: number): Vector;
         /**
          * @name Two.Vector#multiply
          * @function
@@ -364,6 +357,7 @@ declare module "src/vector" {
          * @description Multiply the **same** number to both x / y component values of the instance.
          * @overloaded
          */
+        multiply(v: Vector): Vector;
         /**
          * @name Two.Vector#multiply
          * @function
@@ -372,7 +366,7 @@ declare module "src/vector" {
          * @description Multiply `x` / `y` values to their respective component value on the instance.
          * @overloaded
          */
-        multiply(x: number, y: number, ...args: any[]): Vector;
+        multiply(x: number, y: number): Vector;
         /**
          * @name Two.Vector#multiplySelf
          * @function
@@ -389,10 +383,11 @@ declare module "src/vector" {
         /**
          * @name Two.Vector#divide
          * @function
-         * @param {Two.Vector} v
+         * @param {Vector} v
          * @description Divide an object with x / y component values to the instance.
          * @overloaded
          */
+        divide(v: Vector): Vector;
         /**
          * @name Two.Vector#divide
          * @function
@@ -400,6 +395,7 @@ declare module "src/vector" {
          * @description Divide the **same** number to both x / y component values of the instance.
          * @overloaded
          */
+        divide(v: number): Vector;
         /**
          * @name Two.Vector#divide
          * @function
@@ -408,13 +404,15 @@ declare module "src/vector" {
          * @description Divide `x` / `y` values to their respective component value on the instance.
          * @overloaded
          */
-        divide(x: number, y: number, ...args: any[]): Vector;
+        divide(x: number, y: number): Vector;
         /**
          * @name Two.Vector#divideSelf
          * @function
          * @description Alias for {@link Two.Vector.divide}.
          */
-        divideSelf(v: any, ...args: any[]): any;
+        divideSelf(x: number, y: number): Vector;
+        divideSelf(v: number): Vector;
+        divideSelf(v: Vector): Vector;
         /**
          * @name Two.Vector#divideScalar
          * @function
@@ -429,12 +427,12 @@ declare module "src/vector" {
          */
         negate(): Vector;
         /**
-         * @name Two.Vector#dot
+         * @name Two.Vector#negate
          * @function
          * @returns {Number}
          * @description Get the [dot product](https://en.wikipedia.org/wiki/Dot_product) of the vector.
          */
-        dot(v: any): number;
+        dot(v: Vector): number;
         /**
          * @name Two.Vector#length
          * @function
@@ -468,7 +466,7 @@ declare module "src/vector" {
          * @returns {Number}
          * @description Get the distance between two vectors to the power of two. Widely used as less expensive than {@link Two.Vector#distanceTo} because it isn't square-rooting any numbers.
          */
-        distanceToSquared(v: any): number;
+        distanceToSquared(v: Vector): number;
         /**
          * @name Two.Vector#setLength
          * @function
@@ -479,21 +477,21 @@ declare module "src/vector" {
         /**
          * @name Two.Vector#equals
          * @function
-         * @param {Two.Vector} v - The vector to compare against.
+         * @param {Vector} v - The vector to compare against.
          * @param {Number} [eps=0.0001] - An options epsilon for precision.
          * @returns {Boolean}
          * @description Qualify if one vector roughly equal another. With a margin of error defined by epsilon.
          */
-        equals(v: Two.Vector, eps?: number): boolean;
+        equals(v: Vector, eps?: number): boolean;
         /**
          * @name Two.Vector#lerp
          * @function
-         * @param {Two.Vector} v - The destination vector to step towards.
+         * @param {Vector} v - The destination vector to step towards.
          * @param {Number} t - The zero to one value of how close the current vector gets to the destination vector.
          * @description Linear interpolate one vector to another by an amount `t` defined as a zero to one number.
          * @see [Matt DesLauriers](https://twitter.com/mattdesl/status/1031305279227478016) has a good thread about this.
          */
-        lerp(v: Two.Vector, t: number): Vector;
+        lerp(v: Vector, t: number): Vector;
         /**
          * @name Two.Vector#isZero
          * @function
@@ -502,13 +500,6 @@ declare module "src/vector" {
          * @description Check to see if vector is roughly zero, based on the `epsilon` precision value.
          */
         isZero(eps?: number): boolean;
-        /**
-         * @name Two.Vector#toString
-         * @function
-         * @returns {String}
-         * @description Return a comma-separated string of x, y value. Great for storing in a database.
-         */
-        toString(): string;
         /**
          * @name Two.Vector#toObject
          * @function
@@ -524,8 +515,9 @@ declare module "src/vector" {
          */
         rotate(radians: number): Vector;
     }
+    import { Events } from "two.js/src/events";
 }
-declare module "src/anchor" {
+declare module "two.js/src/anchor" {
     /**
      * @class
      * @name Two.Anchor
@@ -536,10 +528,10 @@ declare module "src/anchor" {
      * @param {Number} [rx=0] - The x position of the right handle point.
      * @param {Number} [ry=0] - The y position of the right handle point.
      * @param {String} [command=Two.Commands.move] - The command to describe how to render. Applicable commands are {@link Two.Commands}
-     * @extends Two.Vector
+
      * @description An object that holds 3 {@link Two.Vector}s, the anchor point and its corresponding handles: `left` and `right`. In order to properly describe the bezier curve about the point there is also a command property to describe what type of drawing should occur when Two.js renders the anchors.
      */
-    export class Anchor {
+    export class Anchor extends Vector {
         static makeBroadcast(scope: any): () => void;
         constructor(x?: number, y?: number, ax?: number, ay?: number, bx?: number, by?: number, command?: string);
         controls: {
@@ -555,45 +547,15 @@ declare module "src/anchor" {
         _sweepFlag: number;
         command: string;
         relative: boolean;
-        /**
-         * @name Two.Anchor#copy
-         * @function
-         * @param {Two.Anchor} v - The anchor to apply values to.
-         * @description Copy the properties of one {@link Two.Anchor} onto another.
-         */
-        copy(v: Two.Anchor): Anchor;
-        x: any;
-        y: any;
         rx: any;
         ry: any;
         xAxisRotation: any;
         largeArcFlag: any;
         sweepFlag: any;
-        /**
-         * @name Two.Anchor#clone
-         * @function
-         * @returns {Two.Anchor}
-         * @description Create a new {@link Two.Anchor}, set all its values to the current instance and return it for use.
-         */
-        clone(): Two.Anchor;
-        /**
-         * @name Two.Anchor#toObject
-         * @function
-         * @returns {Object} - An object with properties filled out to mirror {@link Two.Anchor}.
-         * @description Create a JSON compatible plain object of the current instance. Intended for use with storing values in a database.
-         */
-        toObject(): any;
-        /**
-         * @name Two.Anchor#toString
-         * @function
-         * @returns {String} - A String with comma-separated values reflecting the various values on the current instance.
-         * @description Create a string form of the current instance. Intended for use with storing values in a database. This is lighter to store than the JSON compatible {@link Two.Anchor#toObject}.
-         */
-        toString(): string;
     }
-    import { Vector } from "src/vector";
+    import { Vector } from "two.js/src/vector";
 }
-declare module "src/constants" {
+declare module "two.js/src/constants" {
     export namespace Constants {
         const nextFrameID: any;
         namespace Types {
@@ -610,7 +572,7 @@ declare module "src/constants" {
         function uniqueId(): number;
     }
 }
-declare module "src/utils/curves" {
+declare module "two.js/src/utils/curves" {
     export namespace Curve {
         const CollinearityEpsilon: number;
         const RecursionLimit: number;
@@ -733,10 +695,10 @@ declare module "src/utils/curves" {
      * @param {Boolean} [ccw=false] - Set path traversal to counter-clockwise
      */
     export function getAnchorsFromArcData(center: Vector, xAxisRotation: number, rx: number, ry: number, ts: number, td: number, ccw?: boolean): void;
-    import { Anchor } from "src/anchor";
-    import { Vector } from "src/vector";
+    import { Anchor } from "two.js/src/anchor";
+    import { Vector } from "two.js/src/vector";
 }
-declare module "src/utils/device-pixel-ratio" {
+declare module "two.js/src/utils/device-pixel-ratio" {
     /**
      * @name Two.Utils.getRatio
      * @function
@@ -746,7 +708,7 @@ declare module "src/utils/device-pixel-ratio" {
      */
     export function getRatio(ctx: CanvasRenderingContext2D): number;
 }
-declare module "src/utils/underscore" {
+declare module "two.js/src/utils/underscore" {
     export namespace _ {
         function isNaN(obj: any): boolean;
         function isElement(obj: any): boolean;
@@ -757,14 +719,14 @@ declare module "src/utils/underscore" {
         const performance: any;
     }
 }
-declare module "src/element" {
+declare module "two.js/src/element" {
     /**
      * @name Two.Element
      * @class
-     * @extends Two.Events
+
      * @description The foundational object for the Two.js scenegraph.
      */
-    export class Element {
+    export class Element extends Events {
         /**
          * @name Two.Element#_flagId
          * @private
@@ -808,8 +770,9 @@ declare module "src/element" {
          */
         flagReset(): void;
     }
+    import { Events } from "two.js/src/events";
 }
-declare module "src/matrix" {
+declare module "two.js/src/matrix" {
     /**
      * @name Two.Matrix
      * @class
@@ -834,19 +797,20 @@ declare module "src/matrix" {
         /**
          * @name Two.Matrix.Multiply
          * @function
-         * @param {Two.Matrix} A
-         * @param {Two.Matrix} B
-         * @param {Two.Matrix} [C] - An optional matrix to apply the multiplication to.
-         * @returns {Two.Matrix} - If an optional `C` matrix isn't passed then a new one is created and returned.
+         * @param {Matrix} A
+         * @param {Matrix} B
+         * @param {Matrix} [C] - An optional matrix to apply the multiplication to.
+         * @returns {Matrix} - If an optional `C` matrix isn't passed then a new one is created and returned.
          * @description Multiply two matrices together and return the result.
          */
-        static Multiply(A: Two.Matrix, B: Two.Matrix, C?: Two.Matrix): Two.Matrix;
-        constructor(a: any, b: any, c: any, d: any, e: any, f: any, ...args: any[]);
+        static Multiply(A: Matrix, B: Matrix, C?: Matrix): Matrix;
+        constructor(elements: number[]);
+        constructor(a?: number, b?: number, c?: number, d?: number, e?: number, f?: number);
         /**
          * @name Two.Matrix#elements
          * @property {Number[]} - The underlying data stored as an array.
          */
-        elements: any;
+        elements: number[];
         /**
          * @name Two.Matrix#manual
          * @property {Boolean} - Determines whether Two.js automatically calculates the values for the matrix or if the developer intends to manage the matrix.
@@ -921,10 +885,10 @@ declare module "src/matrix" {
         /**
          * @name Two.Matrix#inverse
          * @function
-         * @param {Two.Matrix} [out] - The optional matrix to apply the inversion to.
+         * @param {Matrix} [out] - The optional matrix to apply the inversion to.
          * @description Return an inverted version of the matrix. If no optional one is passed a new matrix is created and returned.
          */
-        inverse(out?: Two.Matrix): any;
+        inverse(out?: Matrix): any;
         /**
          * @name Two.Matrix#scale
          * @function
@@ -1008,16 +972,16 @@ declare module "src/matrix" {
          */
         clone(): any;
     }
-    import { Events } from "src/events";
+    import { Events } from "two.js/src/events";
 }
-declare module "src/shape" {
+declare module "two.js/src/shape" {
     /**
      * @name Two.Shape
      * @class
-     * @extends Two.Element
+
      * @description The foundational transformation object for the Two.js scenegraph.
      */
-    export class Shape {
+    export class Shape extends TwoElement {
         /**
          * @name Two.Shape#_flagMatrix
          * @private
@@ -1033,19 +997,19 @@ declare module "src/shape" {
         /**
          * @name Two.Shape#_matrix
          * @private
-         * @property {Two.Matrix} - The matrix value of the shape's position, rotation, and scale.
+         * @property {Matrix} - The matrix value of the shape's position, rotation, and scale.
          */
         private _matrix;
         /**
          * @name Two.Shape#_worldMatrix
          * @private
-         * @property {Two.Matrix} - The matrix value of the shape's position, rotation, and scale in the scene.
+         * @property {Matrix} - The matrix value of the shape's position, rotation, and scale in the scene.
          */
         private _worldMatrix;
         /**
          * @name Two.Shape#_position
          * @private
-         * @property {Two.Vector} - The translation values as a {@link Two.Vector}.
+         * @property {Vector} - The translation values as a {@link Two.Vector}.
          */
         private _position;
         /**
@@ -1057,7 +1021,7 @@ declare module "src/shape" {
         /**
          * @name Two.Shape#_scale
          * @private
-         * @property {Number|Two.Vector} - The scale value in Number. Can be a vector for non-uniform scaling.
+         * @property {Number|Vector} - The scale value in Number. Can be a vector for non-uniform scaling.
          */
         private _scale;
         /**
@@ -1081,20 +1045,20 @@ declare module "src/shape" {
         id: string;
         /**
          * @name Two.Shape#matrix
-         * @property {Two.Matrix}
+         * @property {Matrix}
          * @description The transformation matrix of the shape.
          * @nota-bene {@link Two.Shape#position}, {@link Two.Shape#rotation}, {@link Two.Shape#scale}, {@link Two.Shape#skewX}, and {@link Two.Shape#skewY} apply their values to the matrix when changed. The matrix is what is sent to the renderer to be drawn.
          */
         matrix: Matrix;
         /**
          * @name Two.Shape#worldMatrix
-         * @property {Two.Matrix}
+         * @property {Matrix}
          * @description The transformation matrix of the shape in the scene.
          */
         worldMatrix: Matrix;
         /**
          * @name Two.Shape#position
-         * @property {Two.Vector} - The x and y value for where the shape is placed relative to its parent.
+         * @property {Vector} - The x and y value for where the shape is placed relative to its parent.
          */
         position: Vector;
         /**
@@ -1107,7 +1071,7 @@ declare module "src/shape" {
          * @property {Number} - The value for how much the shape is scaled relative to its parent.
          * @nota-bene This value can be replaced with a {@link Two.Vector} to do non-uniform scaling. e.g: `shape.scale = new Two.Vector(2, 1);`
          */
-        scale: number;
+        scale: number|Vector;
         /**
          * @name Two.Shape#skewX
          * @property {Number} - The value in Number for how much the shape is skewed relative to its parent.
@@ -1122,20 +1086,19 @@ declare module "src/shape" {
         skewY: number;
         set renderer(arg: any);
         get renderer(): any;
-        _renderer: any;
-        set translation(arg: any);
+        set translation(arg: Vector);
         /**
          * @name Two.Shape#translation
          * @description Alias for {@link Two.Shape#position}.
          */
-        get translation(): any;
+        get translation(): Vector;
         /**
          * @name Two.Shape#addTo
          * @function
-         * @param {Two.Group} group - The parent the shape adds itself to.
+         * @param {Group} group - The parent the shape adds itself to.
          * @description Convenience method to add itself to the scenegraph.
          */
-        addTo(group: Two.Group): Shape;
+        addTo(group: Group): Shape;
         /**
          * @name Two.Shape#remove
          * @function
@@ -1145,11 +1108,11 @@ declare module "src/shape" {
         /**
          * @name Two.Shape#clone
          * @function
-         * @param {Two.Group} [parent] - Optional argument to automatically add the shape to a scenegraph.
-         * @returns {Two.Shape}
+         * @param {Group} [parent] - Optional argument to automatically add the shape to a scenegraph.
+         * @returns {Shape}
          * @description Create a new {@link Two.Shape} with the same values as the current shape.
          */
-        clone(parent?: Two.Group): Two.Shape;
+        clone(parent?: Group): Shape;
         /**
          * @name Two.Shape#_update
          * @function
@@ -1159,25 +1122,20 @@ declare module "src/shape" {
          * @nota-bene Try not to call this method more than once a frame.
          */
         private _update;
-        /**
-         * @name Two.Shape#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
     }
-    import { Matrix } from "src/matrix";
-    import { Vector } from "src/vector";
+    import { Element as TwoElement } from "two.js/src/element";
+    import { Matrix } from "two.js/src/matrix";
+    import { Vector } from "two.js/src/vector";
+    import { Group } from "two.js/src/group";
 }
-declare module "src/collection" {
+declare module "two.js/src/collection" {
     /**
      * @name Two.Collection
      * @class
-     * @extends Two.Events
+
      * @description An `Array` like object with additional event propagation on actions. `pop`, `shift`, and `splice` trigger `removed` events. `push`, `unshift`, and `splice` with more than 2 arguments trigger 'inserted'. Finally, `sort` and `reverse` trigger `order` events.
      */
-    export class Collection {
+    export class Collection<T = any> extends Array<T> {
         constructor(...args: any[]);
         /**
          * @private
@@ -1195,25 +1153,18 @@ declare module "src/collection" {
         trigger(...args: any[]): any;
         listen(...args: any[]): any;
         ignore(...args: any[]): any;
-        pop(...args: any[]): any;
-        shift(...args: any[]): any;
-        push(...args: any[]): any;
-        unshift(...args: any[]): any;
-        splice(...args: any[]): any;
-        sort(...args: any[]): Collection;
-        reverse(...args: any[]): Collection;
-        indexOf(...args: any[]): any;
     }
 }
-declare module "src/children" {
+declare module "two.js/src/children" {
     /**
      * @class
      * @name Two.Group.Children
-     * @extends Two.Collection
+
      * @description A children collection which is accesible both by index and by object `id`.
      */
-    export class Children {
-        constructor(children: any, ...args: any[]);
+    export class Children extends Collection<TwoElement> {
+        constructor(children?: TwoElement[]);
+        constructor(...args: TwoElement[]);
         /**
          * @name Two.Group.Children#ids
          * @property {Object} - Map of all elements in the list keyed by `id`s.
@@ -1222,44 +1173,47 @@ declare module "src/children" {
         /**
          * @function
          * @name Two.Group.Children#attach
-         * @param {Two.Shape[]} children - The objects which extend {@link Two.Shape} to be added.
+         * @param {Shape[]} children - The objects which extend {@link Two.Shape} to be added.
          * @description Adds elements to the `ids` map.
          */
-        attach(children: Two.Shape[]): Children;
+        attach(children: Shape[]): Children;
         /**
          * @function
          * @name Two.Group.Children#detach
-         * @param {Two.Shape[]} children - The objects which extend {@link Two.Shape} to be removed.
+         * @param {Shape[]} children - The objects which extend {@link Two.Shape} to be removed.
          * @description Removes elements to the `ids` map.
          */
-        detach(children: Two.Shape[]): Children;
+        detach(children: Shape[]): Children;
     }
+    import { Collection } from "two.js/src/collection";
+    import { Shape } from "two.js/src/shape";
+    import { Element as TwoElement } from "two.js/src/element";
 }
-declare module "src/group" {
+declare module "two.js/src/group" {
     /**
      * @name Two.Group
      * @class
-     * @extends Two.Shape
-     * @param {Two.Shape[]} [children] - A list of objects that inherit {@link Two.Shape}. For instance, the array could be a {@link Two.Path}, {@link Two.Text}, and {@link Two.RoundedRectangle}.
+
+     * @param {Shape[]} [children] - A list of objects that inherit {@link Two.Shape}. For instance, the array could be a {@link Two.Path}, {@link Two.Text}, and {@link Two.RoundedRectangle}.
      * @description This is the primary class for grouping objects that are then drawn in Two.js. In Illustrator this is a group, in After Effects it would be a Null Object. Whichever the case, the `Two.Group` contains a transformation matrix and commands to style its children, but it by itself doesn't render to the screen.
      * @nota-bene The {@link Two#scene} is an instance of `Two.Group`.
      */
-    export class Group {
-        static Children: typeof Children;
+    export class Group extends Shape {
+        static Children: Children;
         /**
          * @name Two.Group.InsertChildren
          * @function
-         * @param {Two.Shape[]} children - The objects to be inserted.
+         * @param {Shape[]} children - The objects to be inserted.
          * @description Cached method to let renderers know children have been added to a {@link Two.Group}.
          */
-        static InsertChildren(children: Two.Shape[]): void;
+        static InsertChildren(children: Shape[]): void;
         /**
          * @name Two.Group.RemoveChildren
          * @function
-         * @param {Two.Shape[]} children - The objects to be removed.
+         * @param {Shape[]} children - The objects to be removed.
          * @description Cached method to let renderers know children have been removed from a {@link Two.Group}.
          */
-        static RemoveChildren(children: Two.Shape[]): void;
+        static RemoveChildren(children: Shape[]): void;
         /**
          * @name Two.Group.OrderChildren
          * @function
@@ -1271,7 +1225,8 @@ declare module "src/group" {
          * @property {String[]} - A list of properties that are on every {@link Two.Group}.
          */
         static Properties: string[];
-        constructor(children: any, ...args: any[]);
+        constructor(children?: TwoElement[]);
+        constructor(...args: TwoElement[]);
         /**
          * @name Two.Group#_flagAdditions
          * @private
@@ -1327,117 +1282,109 @@ declare module "src/group" {
         private _flagMask;
         /**
          * @name Two.Group#fill
-         * @property {(String|Two.Gradient|Two.Texture)} - The value of what all child shapes should be filled in with.
+         * @property {(String|Gradient|Texture)} - The value of what all child shapes should be filled in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        _fill: string;
+        fill: string|Gradient|Texture;
         /**
          * @name Two.Group#stroke
-         * @property {(String|Two.Gradient|Two.Texture)} - The value of what all child shapes should be outlined in with.
+         * @property {(String|Gradient|Texture)} - The value of what all child shapes should be outlined in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        _stroke: string;
+        stroke: string|Gradient|Texture;
         /**
          * @name Two.Group#linewidth
          * @property {Number} - The thickness in pixels of the stroke for all child shapes.
          */
-        _linewidth: number;
+        linewidth: number;
         /**
          * @name Two.Group#opacity
          * @property {Number} - The opaqueness of all child shapes.
          * @nota-bene Becomes multiplied by the individual child's opacity property.
          */
-        _opacity: number;
+        opacity: number;
         /**
          * @name Two.Group#visible
          * @property {Boolean} - Display the path or not.
          * @nota-bene For {@link Two.CanvasRenderer} and {@link Two.WebGLRenderer} when set to false all updating is disabled improving performance dramatically with many objects in the scene.
          */
-        _visible: boolean;
+        visible: boolean;
         /**
          * @name Two.Group#cap
          * @property {String}
          * @see {@link https://www.w3.org/TR/SVG11/painting.html#StrokeLinecapProperty}
          */
-        _cap: string;
+        cap: string;
         /**
          * @name Two.Group#join
          * @property {String}
          * @see {@link https://www.w3.org/TR/SVG11/painting.html#StrokeLinejoinProperty}
          */
-        _join: string;
+        join: string;
         /**
          * @name Two.Group#miter
          * @property {String}
          * @see {@link https://www.w3.org/TR/SVG11/painting.html#StrokeMiterlimitProperty}
          */
-        _miter: number;
+        miter: number;
         /**
          * @name Two.Group#closed
          * @property {Boolean} - Determines whether a final line is drawn between the final point in the `vertices` array and the first point of all child shapes.
          */
-        _closed: boolean;
+        closed: boolean;
         /**
          * @name Two.Group#curved
          * @property {Boolean} - When the child's path is `automatic = true` this boolean determines whether the lines between the points are curved or not.
          */
-        _curved: boolean;
+        curved: boolean;
         /**
          * @name Two.Group#automatic
          * @property {Boolean} - Determines whether or not Two.js should calculate curves, lines, and commands automatically for you or to let the developer manipulate them for themselves.
          */
-        _automatic: boolean;
+        automatic: boolean;
         /**
          * @name Two.Group#beginning
          * @property {Number} - Number between zero and one to state the beginning of where the path is rendered.
          * @description {@link Two.Group#beginning} is a percentage value that represents at what percentage into all child shapes should the renderer start drawing.
          * @nota-bene This is great for animating in and out stroked paths in conjunction with {@link Two.Group#ending}.
          */
-        _beginning: number;
+        beginning: number;
         /**
          * @name Two.Group#ending
          * @property {Number} - Number between zero and one to state the ending of where the path is rendered.
          * @description {@link Two.Group#ending} is a percentage value that represents at what percentage into all child shapes should the renderer start drawing.
          * @nota-bene This is great for animating in and out stroked paths in conjunction with {@link Two.Group#beginning}.
          */
-        _ending: number;
+        ending: number;
         /**
          * @name Two.Group#length
          * @property {Number} - The sum of distances between all child lengths.
          */
-        _length: number;
+        length: number;
         /**
          * @name Two.Group#mask
-         * @property {Two.Shape} - The Two.js object to clip from a group's rendering.
+         * @property {Shape} - The Two.js object to clip from a group's rendering.
          */
-        _mask: any;
+        mask: any;
         /**
          * @name Two.Group#additions
-         * @property {Two.Shape[]}
+         * @property {Shape[]}
          * @description An automatically updated list of children that need to be appended to the renderer's scenegraph.
          */
         additions: any[];
         /**
          * @name Two.Group#subtractions
-         * @property {Two.Shape[]}
+         * @property {Shape[]}
          * @description An automatically updated list of children that need to be removed from the renderer's scenegraph.
          */
         subtractions: any[];
         /**
          * @name Two.Group#children
-         * @property {Two.Group.Children}
+         * @property {Group.Children}
          * @description A list of all the children in the scenegraph.
          * @nota-bene Ther order of this list indicates the order each element is rendered to the screen.
          */
-        children: any;
-        /**
-         * @name Two.Group#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Group}
-         * @description Create a new instance of {@link Two.Group} with the same properties of the current group.
-         */
-        clone(parent?: Two.Group): Two.Group;
+        children: Children;
         /**
          * @name Two.Group#toObject
          * @function
@@ -1461,37 +1408,52 @@ declare module "src/group" {
          * @name Two.Group#getById
          * @function
          * @description Recursively search for id. Returns the first element found.
-         * @returns {Two.Shape} - Or `null` if nothing is found.
+         * @returns {Shape} - Or `null` if nothing is found.
          */
-        getById(id: any): Two.Shape;
+        getById(id: any): Shape;
         /**
          * @name Two.Group#getByClassName
          * @function
          * @description Recursively search for classes. Returns an array of matching elements.
-         * @returns {Two.Shape[]} - Or empty array if nothing is found.
+         * @returns {Shape[]} - Or empty array if nothing is found.
          */
-        getByClassName(className: any): Two.Shape[];
+        getByClassName(className: any): Shape[];
         /**
          * @name Two.Group#getByType
          * @function
          * @description Recursively search for children of a specific type, e.g. {@link Two.Path}. Pass a reference to this type as the param. Returns an array of matching elements.
-         * @returns {Two.Shape[]} - Empty array if nothing is found.
+         * @returns {Shape[]} - Empty array if nothing is found.
          */
-        getByType(type: any): Two.Shape[];
+        getByType(type: any): Shape[];
         /**
          * @name Two.Group#add
          * @function
-         * @param {Two.Shape[]|...Two.Shape} objects - An array of objects to be added. Can also be supplied as individual arguments.
+         * @param {Element[]} objects - An array of objects to be added. Can also be supplied as individual arguments.
+         * @params {...Element} [args] - Alternatively pass shapes as each argument
          * @description Add objects to the group.
          */
-        add(objects: any, ...args: any[]): Group;
+        add(objects: TwoElement): Group;
+        add(...args: TwoElement[]): Group;
         /**
          * @name Two.Group#remove
          * @function
-         * @param {Two.Shape[]|...Two.Shape} [objects=self] - An array of objects to be removed. Can be also removed as individual arguments. If no arguments are passed, then it removes itself from its parent.
+         * @description Remove self from the scene / parent.
+         */
+        remove(): Shape;
+        /**
+         * @name Two.Group#remove
+         * @function
+         * @param {Shape[]} objects - An array of objects to be removed. Can also be supplied as individual arguments.
          * @description Remove objects from the group.
          */
-        remove(objects: any, ...args: any[]): Group;
+        remove(objects: Array<Shape>): Shape;
+        /**
+         * @name Two.Group#remove
+         * @function
+         * @params {...Shape} [args] - Alternatively pass shapes as each argument
+         * @description Remove objects from the group.
+         */
+        remove(...args: Shape[]): Shape;
         /**
          * @name Two.Group#getBoundingClientRect
          * @function
@@ -1517,38 +1479,34 @@ declare module "src/group" {
          * @function
          * @description Apply `subdivide` method to all child shapes.
          */
-        subdivide(...args: any[]): Group;
+        subdivide(limit?: number): Group;
         /**
-         * @name Two.Group#_update
+         * @name Two.Group#clone
          * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
+         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Two.Group}
+         * @description Create a new instance of {@link Two.Group} with the same properties of the current group.
          */
-        private _update;
-        /**
-         * @name Two.Group#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
+        clone(parent?: Group): Group;
     }
-    import { Children } from "src/children";
+    import { Shape } from "two.js/src/shape";
+    import { Children } from "two.js/src/children";
+    import { Gradient } from "two.js/src/effects/gradient";
+    import { Texture } from "two.js/src/effects/texture";
+    import { Element as TwoElement } from "two.js/src/element";
 }
-declare module "src/renderers/canvas" {
+declare module "two.js/src/renderers/canvas" {
     /**
      * @name Two.CanvasRenderer
      * @class
-     * @extends Two.Events
+
      * @param {Object} [parameters] - This object is inherited when constructing a new instance of {@link Two}.
      * @param {Element} [parameters.domElement] - The `<canvas />` to draw to. If none given a new one will be constructed.
      * @param {Boolean} [parameters.overdraw] - Determines whether the canvas should clear the background or not. Defaults to `true`.
      * @param {Boolean} [parameters.smoothing=true] - Determines whether the canvas should antialias drawing. Set it to `false` when working with pixel art. `false` can lead to better performance, since it would use a cheaper interpolation algorithm.
      * @description This class is used by {@link Two} when constructing with `type` of `Two.Types.canvas`. It takes Two.js' scenegraph and renders it to a `<canvas />`.
      */
-    export class Renderer {
+    export class Renderer extends Events {
         /**
          * @name Two.CanvasRenderer.Utils
          * @property {Object} - A massive object filled with utility functions and properties to render Two.js objects to a `<canvas />`.
@@ -1585,12 +1543,12 @@ declare module "src/renderers/canvas" {
             };
             renderSvgArcCommand: (ctx: any, ax: any, ay: any, rx: any, ry: any, largeArcFlag: any, sweepFlag: any, xAxisRotation: any, x: any, y: any) => void;
         };
-        constructor(params: any);
+        constructor(params?: any);
         /**
          * @name Two.CanvasRenderer#domElement
          * @property {Element} - The `<canvas />` associated with the Two.js scene.
          */
-        domElement: any;
+        domElement: HTMLElement;
         /**
          * @name Two.CanvasRenderer#ctx
          * @property {Canvas2DContext} - Associated two dimensional context to render on the `<canvas />`.
@@ -1604,7 +1562,7 @@ declare module "src/renderers/canvas" {
         overdraw: any;
         /**
          * @name Two.CanvasRenderer#scene
-         * @property {Two.Group} - The root group of the scenegraph.
+         * @property {Group} - The root group of the scenegraph.
          */
         scene: Group;
         /**
@@ -1627,21 +1585,22 @@ declare module "src/renderers/canvas" {
          */
         render(): Renderer;
     }
-    import { Group } from "src/group";
+    import { Events } from "two.js/src/events";
+    import { Group } from "two.js/src/group";
 }
-declare module "src/utils/canvas-shim" {
+declare module "two.js/src/utils/canvas-shim" {
     export namespace CanvasShim {
         const Image: any;
         const isHeadless: boolean;
         function shim(canvas: any, Image?: new (width?: number, height?: number) => HTMLImageElement): any;
     }
 }
-declare module "src/utils/dom" {
+declare module "two.js/src/utils/dom" {
     export namespace dom {
         const temp: any;
     }
 }
-declare module "src/utils/error" {
+declare module "two.js/src/utils/error" {
     /**
      * @name Two.Utils.Error
      * @class
@@ -1649,10 +1608,9 @@ declare module "src/utils/error" {
      */
     export class TwoError extends Error {
         constructor(message: any);
-        message: any;
     }
 }
-declare module "src/registry" {
+declare module "two.js/src/registry" {
     /**
      * @name Two.Registry
      * @class
@@ -1693,37 +1651,38 @@ declare module "src/registry" {
         contains(id: string): boolean;
     }
 }
-declare module "src/utils/shape" {
+declare module "two.js/src/utils/shape" {
     /**
      * @private
-     * @param {Two.Path} path - The path to analyze against.
+     * @param {Path} path - The path to analyze against.
      * @param {Number} t -
      * @returns {Number}
      * @description
      */
-    export function contains(path: Two.Path, t: number): number;
+    export function contains(path: Path, t: number): number;
     /**
      * @private
-     * @param {Two.Path} path - The path to analyze against.
+     * @param {Path} path - The path to analyze against.
      * @param {Number} target - The target length at which to find an anchor.
      * @returns {Number}
      * @description Return the id of an anchor based on a target length.
      */
-    export function getIdByLength(path: Two.Path, target: number): number;
+    export function getIdByLength(path: Path, target: number): number;
     export function getCurveLength(a: any, b: any, limit: any): number;
-    export function getSubdivisions(a: any, b: any, limit: any): import("src/anchor").Anchor[];
+    export function getSubdivisions(a: any, b: any, limit: any): import("two.js/src/anchor").Anchor[];
+    import { Path } from "two.js/src/path";
 }
-declare module "src/effects/stop" {
+declare module "two.js/src/effects/stop" {
     /**
      * @name Two.Stop
      * @class
-     * @extends Two.Element
+
      * @param {Number} [offset] - The offset percentage of the stop represented as a zero-to-one value. Default value flip flops from zero-to-one as new stops are created.
      * @param {String} [color] - The color of the stop. Default value flip flops from white to black as new stops are created.
      * @param {Number} [opacity] - The opacity value. Default value is 1, cannot be lower than 0.
      * @nota-bene Used specifically in conjunction with {@link Two.Gradient}s to control color graduation.
      */
-    export class Stop {
+    export class Stop extends TwoElement {
         /**
          * @name Two.Stop.Index
          * @property {Number} - The current index being referenced for calculating a stop's default offset value.
@@ -1734,7 +1693,7 @@ declare module "src/effects/stop" {
          * @property {String[]} - A list of properties that are on every {@link Two.Stop}.
          */
         static Properties: string[];
-        constructor(offset: any, color: any, opacity: any);
+        constructor(offset?: number, color?: string, opacity?: number);
         /**
          * @name Two.Stop#_flagOffset
          * @private
@@ -1779,7 +1738,6 @@ declare module "src/effects/stop" {
         /**
          * @name Two.Stop#opacity
          * @property {Number} - The alpha percentage of the stop represented as a zero-to-one value.
-         * @nota-bene This is only supported on the {@link Two.SVGRenderer}. You can get the same effect by encoding opacity into `rgba` strings in the color.
          */
         opacity: number;
         /**
@@ -1790,11 +1748,11 @@ declare module "src/effects/stop" {
         /**
          * @name Two.Stop#clone
          * @function
-         * @param {Two.Gradient} [parent] - The parent gradient to add the clone to.
-         * @returns {Two.Stop}
+         * @param {Gradient} [parent] - The parent group or scene to add the clone to.
+         * @returns {Stop}
          * @description Create a new instance of {@link Two.Stop} with the same properties of the current path.
          */
-        clone(parent?: Two.Gradient): Two.Stop;
+        clone(parent: Gradient): Stop;
         /**
          * @name Two.Stop#toObject
          * @function
@@ -1802,35 +1760,30 @@ declare module "src/effects/stop" {
          * @description Return a JSON compatible plain object that represents the path.
          */
         toObject(): any;
-        /**
-         * @name Two.Stop#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
     }
+    import { Element as TwoElement } from "two.js/src/element";
+    import { Gradient } from "two.js/src/effects/gradient";
 }
-declare module "src/effects/gradient" {
+declare module "two.js/src/effects/gradient" {
     /**
      * @name Two.Gradient
      * @class
-     * @extends Two.Element
-     * @param {Two.Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
+
+     * @param {Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
      * @description This is the base class for constructing different types of gradients with Two.js. The two common gradients are {@link Two.LinearGradient} and {@link Two.RadialGradient}.
      */
-    export class Gradient {
+    export class Gradient extends TwoElement {
         /**
          * @name Two.Gradient.Stop
          * @see {@link Two.Stop}
          */
-        static Stop: typeof Stop;
+        static Stop: Stop;
         /**
          * @name Two.Gradient.Properties
          * @property {String[]} - A list of properties that are on every {@link Two.Gradient}.
          */
         static Properties: string[];
-        constructor(stops: any);
+        constructor(stops?: Stop[]);
         _flagStops: boolean;
         _flagSpread: boolean;
         _flagUnits: boolean;
@@ -1848,7 +1801,6 @@ declare module "src/effects/gradient" {
          * @nota-bene In the {@link Two.SvgRenderer} change this to change the underlying SVG element's id too.
          */
         id: string;
-        classList: any[];
         /**
          * @name Two.Gradient#spread
          * @property {String} - Indicates what happens if the gradient starts or ends inside the bounds of the target rectangle. Possible values are `'pad'`, `'reflect'`, and `'repeat'`.
@@ -1865,11 +1817,11 @@ declare module "src/effects/gradient" {
         /**
          * @name Two.Gradient#clone
          * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Gradient}
+         * @param {Group} [parent] - The parent group or scene to add the clone to.
+         * @returns {Gradient}
          * @description Create a new instance of {@link Two.Gradient} with the same properties of the current path.
          */
-        clone(parent?: Two.Group): Two.Gradient;
+        clone(parent?: Group): Gradient;
         /**
          * @name Two.Gradient#toObject
          * @function
@@ -1886,36 +1838,25 @@ declare module "src/effects/gradient" {
          * @nota-bene Try not to call this method more than once a frame.
          */
         private _update;
-        /**
-         * @name Two.Gradient#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
     }
-    import { Stop } from "src/effects/stop";
+    import { Element as TwoElement } from "two.js/src/element";
+    import { Stop } from "two.js/src/effects/stop";
+    import { Group } from "two.js/src/group";
 }
-declare module "src/effects/linear-gradient" {
+declare module "two.js/src/effects/linear-gradient" {
     /**
      * @name Two.LinearGradient
      * @class
-     * @extends Two.Gradient
+
      * @param {Number} [x1=0] - The x position of the first end point of the linear gradient.
      * @param {Number} [y1=0] - The y position of the first end point of the linear gradient.
      * @param {Number} [x2=0] - The x position of the second end point of the linear gradient.
      * @param {Number} [y2=0] - The y position of the second end point of the linear gradient.
-     * @param {Two.Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
+     * @param {Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
      * @nota-bene The linear gradient lives within the space of the parent object's matrix space.
      */
-    export class LinearGradient {
-        static Properties: string[];
-        /**
-         * @name Two.LinearGradient.Stop
-         * @see {@link Two.Stop}
-         */
-        static Stop: typeof Stop;
-        constructor(x1: any, y1: any, x2: any, y2: any, stops: any);
+    export class LinearGradient extends Gradient {
+        constructor(x1?: number, y1?: number, x2?: number, y2?: number, stops?: Stop[]);
         /**
          * @name Two.LinearGradient#_flagEndPoints
          * @private
@@ -1926,74 +1867,34 @@ declare module "src/effects/linear-gradient" {
         _right: any;
         /**
          * @name Two.LinearGradient#left
-         * @property {Two.Vector} - The x and y value for where the first end point is placed on the canvas.
+         * @property {Vector} - The x and y value for where the first end point is placed on the canvas.
          */
         left: Vector;
         /**
          * @name Two.LinearGradient#right
-         * @property {Two.Vector} - The x and y value for where the second end point is placed on the canvas.
+         * @property {Vector} - The x and y value for where the second end point is placed on the canvas.
          */
         right: Vector;
-        /**
-         * @name Two.LinearGradient#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Gradient}
-         * @description Create a new instance of {@link Two.LinearGradient} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.Gradient;
-        /**
-         * @name Two.LinearGradient#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
-        /**
-         * @name Two.LinearGradient#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.LinearGradient#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
     }
-    import { Vector } from "src/vector";
-    import { Stop } from "src/effects/stop";
+    import { Gradient } from "two.js/src/effects/gradient";
+    import { Stop } from "two.js/src/effects/stop";
+    import { Vector } from "two.js/src/vector";
 }
-declare module "src/effects/radial-gradient" {
+declare module "two.js/src/effects/radial-gradient" {
     /**
      * @name Two.RadialGradient
      * @class
-     * @extends Two.Gradient
+
      * @param {Number} [x=0] - The x position of the origin of the radial gradient.
      * @param {Number} [y=0] - The y position of the origin of the radial gradient.
      * @param {Number} [radius=0] - The radius of the radial gradient.
-     * @param {Two.Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
+     * @param {Stop[]} [stops] - A list of {@link Two.Stop}s that contain the gradient fill pattern for the gradient.
      * @param {Number} [focalX=0] - The x position of the focal point on the radial gradient.
      * @param {Number} [focalY=0] - The y position of the focal point on the radial gradient.
      * @nota-bene The radial gradient lives within the space of the parent object's matrix space.
      */
-    export class RadialGradient {
-        /**
-         * @name Two.RadialGradient.Stop
-         * @see {@link Two.Stop}
-         */
-        static Stop: typeof Stop;
-        /**
-         * @name Two.RadialGradient.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.RadialGradient}.
-         */
-        static Properties: string[];
-        constructor(cx: any, cy: any, r: any, stops: any, fx: any, fy: any);
+    export class RadialGradient extends Gradient {
+        constructor(cx?: number, cy?: number, r?: number, stops?: Stop[], fx?: number, fy?: number);
         /**
          * @name Two.RadialGradient#_flagRadius
          * @private
@@ -2017,61 +1918,31 @@ declare module "src/effects/radial-gradient" {
         _focal: any;
         /**
          * @name Two.RadialGradient#center
-         * @property {Two.Vector} - The x and y value for where the origin of the radial gradient is.
+         * @property {Vector} - The x and y value for where the origin of the radial gradient is.
          */
         center: Vector;
         radius: number;
         /**
          * @name Two.RadialGradient#focal
-         * @property {Two.Vector} - The x and y value for where the focal point of the radial gradient is.
+         * @property {Vector} - The x and y value for where the focal point of the radial gradient is.
          * @nota-bene This effects the spray or spread of the radial gradient.
          */
         focal: Vector;
-        /**
-         * @name Two.RadialGradient#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Gradient}
-         * @description Create a new instance of {@link Two.RadialGradient} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.Gradient;
-        /**
-         * @name Two.RadialGradient#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
-        /**
-         * @name Two.RadialGradient#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.RadialGradient#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
     }
-    import { Vector } from "src/vector";
-    import { Stop } from "src/effects/stop";
+    import { Gradient } from "two.js/src/effects/gradient";
+    import { Stop } from "two.js/src/effects/stop";
+    import { Vector } from "two.js/src/vector";
 }
-declare module "src/effects/texture" {
+declare module "two.js/src/effects/texture" {
     /**
      * @name Two.Texture
      * @class
-     * @extends Two.Element
+
      * @param {String|HTMLImageElement} [src] - The URL path to an image file or an `<img />` element.
      * @param {Function} [callback] - An optional callback function once the image has been loaded.
      * @description Fundamental to work with bitmap data, a.k.a. pregenerated imagery, in Two.js. Supported formats include jpg, png, gif, and tiff. See {@link Two.Texture.RegularExpressions} for a full list of supported formats.
      */
-    export class Texture {
+    export class Texture extends TwoElement {
         /**
          * @name Two.Texture.Properties
          * @property {String[]} - A list of properties that are on every {@link Two.Texture}.
@@ -2088,7 +1959,7 @@ declare module "src/effects/texture" {
         };
         /**
          * @name Two.Texture.ImageRegistry
-         * @property {Two.Registry} - A canonical listing of image data used in a single session of Two.js.
+         * @property {Registry} - A canonical listing of image data used in a single session of Two.js.
          * @nota-bene This object is used to cache image data between different textures.
          */
         static ImageRegistry: Registry;
@@ -2102,18 +1973,18 @@ declare module "src/effects/texture" {
         /**
          * @name Two.Texture.loadHeadlessBuffer
          * @property {Function} - Loads an image as a buffer in headless environments.
-         * @param {Two.Texture} texture - The {@link Two.Texture} to be loaded.
+         * @param {Texture} texture - The {@link Two.Texture} to be loaded.
          * @param {Function} loaded - The callback function to be triggered once the image is loaded.
          * @nota-bene - This function uses node's `fs.readFileSync` to spoof the `<img />` loading process in the browser.
          */
-        static loadHeadlessBuffer(texture: Two.Texture, loaded: Function): void;
+        static loadHeadlessBuffer(texture: Texture, loaded: Function): void;
         /**
          * @name Two.Texture.getTag
          * @property {Function} - Retrieves the tag name of an image, video, or canvas node.
          * @param {HTMLImageElement} image - The image to infer the tag name from.
          * @returns {String} - Returns the tag name of an image, video, or canvas node.
          */
-        static getTag(image: HTMLImageElement): string;
+        static getTag(image: any): string;
         /**
          * @name Two.Texture.getImage
          * @property {Function} - Convenience function to set {@link Two.Texture#image} properties with canonincal versions set in {@link Two.Texture.ImageRegistry}.
@@ -2134,11 +2005,11 @@ declare module "src/effects/texture" {
         /**
          * @name Two.Texture.load
          * @function
-         * @param {Two.Texture} texture - The texture to load.
+         * @param {Texture} texture - The texture to load.
          * @param {Function} callback - The function to be called once the texture is loaded.
          */
-        static load(texture: Two.Texture, callback: Function): void;
-        constructor(src: any, callback: any);
+        static load(texture: Texture, callback: Function): void;
+        constructor(src?: any, callback?: Function);
         /**
          * @name Two.Texture#_flagSrc
          * @private
@@ -2217,9 +2088,7 @@ declare module "src/effects/texture" {
          * @see {@link Two.Texture#offset}
          */
         private _offset;
-        _renderer: {};
         id: string;
-        classList: any[];
         /**
          * @name Two.Texture#loaded
          * @property {Boolean} - Shorthand value to determine if image has been loaded into the texture.
@@ -2233,7 +2102,7 @@ declare module "src/effects/texture" {
         repeat: string;
         /**
          * @name Two.Texture#offset
-         * @property {Two.Vector} - A two-component vector describing any pixel offset of the texture when applied to a {@link Two.Path}.
+         * @property {Vector} - A two-component vector describing any pixel offset of the texture when applied to a {@link Two.Path}.
          */
         offset: Vector;
         src: string;
@@ -2246,10 +2115,10 @@ declare module "src/effects/texture" {
         /**
          * @name Two.Texture#clone
          * @function
-         * @returns {Two.Texture}
+         * @returns {Texture}
          * @description Create a new instance of {@link Two.Texture} with the same properties of the current texture.
          */
-        clone(): Two.Texture;
+        clone(): Texture;
         /**
          * @name Two.Texture#toObject
          * @function
@@ -2266,38 +2135,32 @@ declare module "src/effects/texture" {
          * @nota-bene Try not to call this method more than once a frame.
          */
         private _update;
-        /**
-         * @name Two.Texture#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
     }
-    import { Vector } from "src/vector";
-    import { Registry } from "src/registry";
+    import { Element as TwoElement } from "two.js/src/element";
+    import { Vector } from "two.js/src/vector";
+    import { Registry } from "two.js/src/registry";
 }
-declare module "src/path" {
+declare module "two.js/src/path" {
     /**
      * @name Two.Path
      * @class
-     * @extends Two.Shape
-     * @param {Two.Anchor[]} [vertices] - A list of {@link Two.Anchor}s that represent the order and coordinates to construct the rendered shape.
+
+     * @param {Anchor[]} [vertices] - A list of {@link Two.Anchor}s that represent the order and coordinates to construct the rendered shape.
      * @param {Boolean} [closed=false] - Describes whether the shape is closed or open.
      * @param {Boolean} [curved=false] - Describes whether the shape automatically calculates bezier handles for each vertex.
      * @param {Boolean} [manual=false] - Describes whether the developer controls how vertices are plotted or if Two.js automatically plots coordinates based on closed and curved booleans.
      * @description This is the primary primitive class for creating all drawable shapes in Two.js. Unless specified methods return their instance of `Two.Path` for the purpose of chaining.
      */
-    export class Path {
+    export class Path extends Shape {
         /**
          * @name Two.Path.Properties
          * @property {String[]} - A list of properties that are on every {@link Two.Path}.
          */
         static Properties: string[];
         static Utils: {
-            getCurveLength: typeof getCurveLength;
+            getCurveLength: Function;
         };
-        constructor(vertices: any, closed: any, curved: any, manual: any);
+        constructor(vertices?: Anchor[], closed?: boolean, curved?: boolean, manual?: boolean);
         /**
          * @name Two.Path#_flagVertices
          * @private
@@ -2498,16 +2361,16 @@ declare module "src/path" {
         ending: number;
         /**
          * @name Two.Path#fill
-         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be filled in with.
+         * @property {(String|Gradient|Texture)} - The value of what the path should be filled in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        fill: string;
+        fill: string|Gradient|Texture;
         /**
          * @name Two.Path#stroke
-         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be outlined in with.
+         * @property {(String|Gradient|Texture)} - The value of what the path should be outlined in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        stroke: string;
+        stroke: string|Gradient|Texture;
         /**
          * @name Two.Path#linewidth
          * @property {Number} - The thickness in pixels of the stroke.
@@ -2551,7 +2414,7 @@ declare module "src/path" {
         miter: number;
         /**
          * @name Two.Path#vertices
-         * @property {Two.Anchor[]} - An ordered list of anchor points for rendering the path.
+         * @property {Anchor[]} - An ordered list of anchor points for rendering the path.
          * @description A list of {@link Two.Anchor} objects that consist of what form the path takes.
          * @nota-bene The array when manipulating is actually a {@link Two.Collection}.
          */
@@ -2567,15 +2430,7 @@ declare module "src/path" {
          * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
          */
-        dashes: any[];
-        /**
-         * @name Two.Path#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Path}
-         * @description Create a new instance of {@link Two.Path} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.Path;
+        dashes: number[];
         /**
          * @name Two.Path#toObject
          * @function
@@ -2619,11 +2474,11 @@ declare module "src/path" {
          * @name Two.Path#getPointAt
          * @function
          * @param {Number} t - Percentage value describing where on the {@link Two.Path} to estimate and assign coordinate values.
-         * @param {Two.Vector} [obj] - Object to apply calculated x, y to. If none available returns new `Object`.
+         * @param {Vector} [obj] - Object to apply calculated x, y to. If none available returns new `Object`.
          * @returns {Object}
          * @description Given a float `t` from 0 to 1, return a point or assign a passed `obj`'s coordinates to that percentage on this {@link Two.Path}'s curve.
          */
-        getPointAt(t: number, obj?: Two.Vector): any;
+        getPointAt(t: number, obj: any): any;
         /**
          * @name Two.Path#plot
          * @function
@@ -2648,24 +2503,11 @@ declare module "src/path" {
          */
         private _updateLength;
         _lengths: any[];
-        /**
-         * @name Two.Path#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.Path#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
     }
-    import { getCurveLength } from "src/utils/shape";
+    import { Anchor } from "two.js/src/anchor";
+    import { Shape } from "two.js/src/shape";
+    import { Gradient } from "two.js/src/effects/gradient";
+    import { Texture } from "two.js/src/effects/texture";
     /**
      * @name FlagVertices
      * @private
@@ -2712,23 +2554,18 @@ declare module "src/path" {
         _flagStroke: boolean;
     }
 }
-declare module "src/shapes/rectangle" {
+declare module "two.js/src/shapes/rectangle" {
     /**
      * @name Two.Rectangle
      * @class
-     * @extends Two.Path
+
      * @param {Number} [x=0] - The x position of the rectangle.
      * @param {Number} [y=0] - The y position of the rectangle.
      * @param {Number} [width=1] - The width value of the rectangle.
      * @param {Number} [height=1] - The width value of the rectangle.
      */
-    export class Rectangle {
-        /**
-         * @name Two.Rectangle.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.Rectangle}.
-         */
-        static Properties: string[];
-        constructor(x: any, y: any, width: any, height: any);
+    export class Rectangle extends Path {
+        constructor(x?: number, y?: number, width?: number, height?: number);
         /**
          * @name Two.Rectangle#width
          * @property {Number} - The size of the width of the rectangle.
@@ -2768,47 +2605,17 @@ declare module "src/shapes/rectangle" {
          * @see {@link Two.Rectangle#height}
          */
         private _height;
-        _origin: any;
-        /**
-         * @name Two.Rectangle#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.Rectangle#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
-        /**
-         * @name Two.Rectangle#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Rectangle}
-         * @description Create a new instance of {@link Two.Rectangle} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.Rectangle;
-        /**
-         * @name Two.Rectangle#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
+        private _origin: Vector;
     }
-    import { Vector } from "src/vector";
+    import { Path } from "two.js/src/path";
+    import { Vector } from "two.js/src/vector";
 }
-declare module "src/effects/sprite" {
+declare module "two.js/src/effects/sprite" {
     /**
      * @name Two.Sprite
      * @class
-     * @extends Two.Rectangle
-     * @param {String|Two.Texture} [path] - The URL path or {@link Two.Texture} to be used as the bitmap data displayed on the sprite.
+
+     * @param {String|Texture} [path] - The URL path or {@link Two.Texture} to be used as the bitmap data displayed on the sprite.
      * @param {Number} [ox=0] - The initial `x` position of the Two.Sprite.
      * @param {Number} [oy=0] - The initial `y` position of the Two.Sprite.
      * @param {Number} [cols=1] - The number of columns the sprite contains.
@@ -2816,13 +2623,8 @@ declare module "src/effects/sprite" {
      * @param {Number} [frameRate=0] - The frame rate at which the partitions of the image should playback at.
      * @description A convenient package to display still or animated images through a tiled image source. For more information on the principals of animated imagery through tiling see [Texture Atlas](https://en.wikipedia.org/wiki/Texture_atlas) on Wikipedia.
      */
-    export class Sprite {
-        /**
-         * @name Two.Sprite.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.Sprite}.
-         */
-        static Properties: string[];
-        constructor(path: any, ox: any, oy: any, cols: any, rows: any, frameRate: any);
+    export class Sprite extends Rectangle {
+        constructor(path?: any, ox?: number, oy?: number, cols?: number, rows?: number, frameRate?: number);
         /**
          * @name Two.Sprite#_flagTexture
          * @private
@@ -2925,14 +2727,7 @@ declare module "src/effects/sprite" {
          * @property {Number} - The current frame the {@link Two.Sprite} is currently displaying.
          */
         private _index;
-        /**
-         * @name Two.Sprite#_origin
-         * @private
-         * @see {@link Two.Sprite#origin}
-         */
-        private _origin;
         texture: Texture;
-        origin: Vector;
         columns: number;
         rows: number;
         frameRate: number;
@@ -2963,61 +2758,21 @@ declare module "src/effects/sprite" {
          * @description Halt animation playback of a {@link Two.Sprite} and set the current frame back to the first frame.
          */
         stop(): Sprite;
-        /**
-         * @name Two.Sprite#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Sprite}
-         * @description Create a new instance of {@link Two.Sprite} with the same properties of the current sprite.
-         */
-        clone(parent?: Two.Group): Two.Sprite;
-        /**
-         * @name Two.Sprite#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
-        /**
-         * @name Two.Sprite#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        fill: any;
-        width: any;
-        height: any;
-        /**
-         * @name Two.Sprite#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
     }
-    import { Texture } from "src/effects/texture";
-    import { Vector } from "src/vector";
+    import { Rectangle } from "two.js/src/shapes/rectangle";
+    import { Texture } from "two.js/src/effects/texture";
 }
-declare module "src/shapes/circle" {
+declare module "two.js/src/shapes/circle" {
     /**
      * @name Two.Circle
      * @class
-     * @extends Two.Path
+
      * @param {Number} [x=0] - The x position of the circle.
      * @param {Number} [y=0] - The y position of the circle.
      * @param {Number} [radius=0] - The radius value of the circle.
      * @param {Number} [resolution=4] - The number of vertices used to construct the circle.
      */
-    export class Circle {
-        /**
-         * @name Two.Circle.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.Circle}.
-         */
-        static Properties: string[];
-        constructor(ox: any, oy: any, r: any, resolution: any);
+    export class Circle extends Path {
         /**
          * @name Two.Circle#_flagRadius
          * @private
@@ -3030,58 +2785,24 @@ declare module "src/shapes/circle" {
          * @see {@link Two.Circle#radius}
          */
         private _radius;
+        constructor(x?: number, y?: number, radius?: number, resolution?:number);
         radius: number;
-        /**
-         * @name Two.Circle#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.Circle#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
-        /**
-         * @name Two.Circle#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Circle}
-         * @description Create a new instance of {@link Two.Circle} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.Circle;
-        /**
-         * @name Two.Circle#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
     }
+    import { Path } from "two.js/src/path";
 }
-declare module "src/shapes/ellipse" {
+declare module "two.js/src/shapes/ellipse" {
     /**
      * @name Two.Ellipse
      * @class
-     * @extends Two.Path
+
      * @param {Number} [x=0] - The x position of the ellipse.
      * @param {Number} [y=0] - The y position of the ellipse.
      * @param {Number} [rx=0] - The radius value of the ellipse in the x direction.
      * @param {Number} [ry=0] - The radius value of the ellipse in the y direction.
      * @param {Number} [resolution=4] - The number of vertices used to construct the ellipse.
      */
-    export class Ellipse {
-        /**
-         * @name Two.Ellipse.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.Ellipse}.
-         */
-        static Properties: string[];
-        constructor(x: any, y: any, rx: any, ry: any, resolution: any);
+    export class Ellipse extends Path {
+        constructor(x?: number, y?: number, rx?: number, ry?: number, resolution?: number);
         /**
          * @name Two.Ellipse#_flagWidth
          * @private
@@ -3108,59 +2829,29 @@ declare module "src/shapes/ellipse" {
         private _height;
         width: number;
         height: number;
-        /**
-         * @name Two.Ellipse#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.Ellipse#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
-        /**
-         * @name Two.Ellipse#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Ellipse}
-         * @description Create a new instance of {@link Two.Ellipse} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.Ellipse;
-        /**
-         * @name Two.Ellipse#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
     }
+    import { Path } from "two.js/src/path";
 }
-declare module "src/shapes/line" {
+declare module "two.js/src/shapes/line" {
     /**
      * @name Two.Line
      * @class
-     * @extends Two.Path
+
      * @param {Number} [x1=0] - The x position of the first vertex on the line.
      * @param {Number} [y1=0] - The y position of the first vertex on the line.
      * @param {Number} [x2=0] - The x position of the second vertex on the line.
      * @param {Number} [y2=0] - The y position of the second vertex on the line.
      */
-    export class Line {
-        constructor(x1: any, y1: any, x2: any, y2: any);
-        automatic: boolean;
+    export class Line extends Path {
+      constructor(x1?: number, y1?: number, x2?: number, y2?: number);
     }
+    import { Path } from "two.js/src/path";
 }
-declare module "src/shapes/rounded-rectangle" {
+declare module "two.js/src/shapes/rounded-rectangle" {
     /**
      * @name Two.RoundedRectangle
      * @class
-     * @extends Two.Path
+
      * @param {Number} [x=0] - The x position of the rounded rectangle.
      * @param {Number} [y=0] - The y position of the rounded rectangle.
      * @param {Number} [width=0] - The width value of the rounded rectangle.
@@ -3168,13 +2859,8 @@ declare module "src/shapes/rounded-rectangle" {
      * @param {Number} [radius=0] - The radius value of the rounded rectangle.
      * @param {Number} [resolution=12] - The number of vertices used to construct the rounded rectangle.
      */
-    export class RoundedRectangle {
-        /**
-         * @name Two.RoundedRectangle.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.RoundedRectangle}.
-         */
-        static Properties: string[];
-        constructor(x: any, y: any, width: any, height: any, radius: any);
+    export class RoundedRectangle extends Path {
+        constructor(x?: number, y?: number, width?: number, height?: number, radius?: number);
         /**
          * @name Two.RoundedRectangle#_flagWidth
          * @private
@@ -3212,56 +2898,25 @@ declare module "src/shapes/rounded-rectangle" {
          */
         private _radius;
         closed: boolean;
-        automatic: boolean;
         width: number;
         height: number;
         radius: number;
-        /**
-         * @name Two.RoundedRectangle#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.RoundedRectangle#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
-        /**
-         * @name Two.RoundedRectangle#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.RoundedRectangle}
-         * @description Create a new instance of {@link Two.RoundedRectangle} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.RoundedRectangle;
-        /**
-         * @name Two.RoundedRectangle#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
     }
+    import { Path } from "two.js/src/path";
 }
-declare module "src/text" {
+declare module "two.js/src/text" {
     /**
      * @name Two.Text
      * @class
-     * @extends Two.Shape
+
      * @param {String} [message] - The String to be rendered to the scene.
      * @param {Number} [x=0] - The position in the x direction for the object.
      * @param {Number} [y=0] - The position in the y direction for the object.
      * @param {Object} [styles] - An object where styles are applied. Attribute must exist in Two.Text.Properties.
      * @description This is a primitive class for creating drawable text that can be added to the scenegraph.
-     * @returns {Two.Text}
+     * @returns {Text}
      */
-    export class Text {
+    export class Text extends Shape {
         /**
          * @name Two.Text.Ratio
          * @property {Number} - Approximate aspect ratio of a typeface's character width to height.
@@ -3272,15 +2927,7 @@ declare module "src/text" {
          * @property {String[]} - A list of properties that are on every {@link Two.Text}.
          */
         static Properties: string[];
-        /**
-         *
-         * @name Two.Measure
-         * @function
-         * @param {Two.Text} [text] - The instance of {@link Two.Text} to measure.
-         * @returns {Object} - The width and height of the {@link Two.Text} instance.
-         */
-        static Measure(text?: Two.Text): any;
-        constructor(message: any, x: any, y: any, styles: any);
+        constructor(message?: string, x?: number, y?: number, styles?: any);
         /**
          * @name Two.Text#_flagValue
          * @private
@@ -3381,111 +3028,105 @@ declare module "src/text" {
          * @name Two.Text#value
          * @property {String} - The characters to be rendered to the the screen. Referred to in the documentation sometimes as the `message`.
          */
-        _value: string;
-        /**
-         * @name Two.Text#family
-         * @property {String} - The font family Two.js should attempt to regsiter for rendering. The default value is `'sans-serif'`. Comma separated font names can be supplied as a "stack", similar to the CSS implementation of `font-family`.
-         */
-        _family: string;
-        /**
-         * @name Two.Text#size
-         * @property {Number} - The font size in Two.js point space. Defaults to `13`.
-         */
-        _size: number;
-        /**
-         * @name Two.Text#leading
-         * @property {Number} - The height between lines measured from base to base in Two.js point space. Defaults to `17`.
-         */
-        _leading: number;
-        /**
-         * @name Two.Text#alignment
-         * @property {String} - Alignment of text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'left'`, `'center'`, `'right'`. Defaults to `'center'`.
-         */
-        _alignment: string;
-        /**
-         * @name Two.Text#baseline
-         * @property {String} - The vertical aligment of the text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'top'`, `'middle'`, `'bottom'`, and `'baseline'`. Defaults to `'baseline'`.
-         * @nota-bene In headless environments where the canvas is based on {@link https://github.com/Automattic/node-canvas}, `baseline` seems to be the only valid property.
-         */
-        _baseline: string;
-        /**
-         * @name Two.Text#style
-         * @property {String} - The font's style. Possible values include '`normal`', `'italic'`. Defaults to `'normal'`.
-         */
-        _style: string;
-        /**
-         * @name Two.Text#weight
-         * @property {Number} - A number at intervals of 100 to describe the font's weight. This compatibility varies with the typeface's variant weights. Larger values are bolder. Smaller values are thinner. Defaults to `'500'`.
-         */
-        _weight: number;
-        /**
-         * @name Two.Text#decoration
-         * @property {String} - String to delineate whether text should be decorated with for instance an `'underline'`. Defaults to `'none'`.
-         */
-        _decoration: string;
-        /**
-         * @name Two.Text#fill
-         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the text object should be filled in with.
-         * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
-         */
-        _fill: string;
-        /**
-         * @name Two.Text#stroke
-         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the text object should be filled in with.
-         * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
-         */
-        _stroke: string;
-        /**
-         * @name Two.Text#linewidth
-         * @property {Number} - The thickness in pixels of the stroke.
-         */
-        _linewidth: number;
-        /**
-         * @name Two.Text#opacity
-         * @property {Number} - The opaqueness of the text object.
-         * @nota-bene Can be used in conjunction with CSS Colors that have an alpha value.
-         */
-        _opacity: number;
-        /**
-         * @name Two.Text#visible
-         * @property {Boolean} - Display the text object or not.
-         * @nota-bene For {@link Two.CanvasRenderer} and {@link Two.WebGLRenderer} when set to false all updating is disabled improving performance dramatically with many objects in the scene.
-         */
-        _visible: boolean;
-        /**
-         * @name Two.Text#mask
-         * @property {Two.Shape} - The shape whose alpha property becomes a clipping area for the text.
-         * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
-         */
-        _mask: any;
-        /**
-         * @name Two.Text#clip
-         * @property {Two.Shape} - Object to define clipping area.
-         * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
-         */
-        _clip: boolean;
         /**
          * @name Two.Text#_dashes
          * @private
          * @see {@link Two.Text#dashes}
          */
         private _dashes;
-        value: any;
+        /**
+         * @name Two.Text#value
+         * @property {String} - The characters to be rendered to the the screen. Referred to in the documentation sometimes as the `message`.
+         */
+        value: string;
+        /**
+         * @name Two.Text#family
+         * @property {String} - The font family Two.js should attempt to regsiter for rendering. The default value is `'sans-serif'`. Comma separated font names can be supplied as a "stack", similar to the CSS implementation of `font-family`.
+         */
+        family: string;
+        /**
+         * @name Two.Text#size
+         * @property {Number} - The font size in Two.js point space. Defaults to `13`.
+         */
+        size: number;
+        /**
+         * @name Two.Text#leading
+         * @property {Number} - The height between lines measured from base to base in Two.js point space. Defaults to `17`.
+         */
+        leading: number;
+        /**
+         * @name Two.Text#alignment
+         * @property {String} - Alignment of text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'left'`, `'center'`, `'right'`. Defaults to `'center'`.
+         */
+        alignment: string;
+        /**
+         * @name Two.Text#baseline
+         * @property {String} - The vertical aligment of the text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'top'`, `'middle'`, `'bottom'`, and `'baseline'`. Defaults to `'baseline'`.
+         */
+        baseline: string;
+        /**
+         * @name Two.Text#style
+         * @property {String} - The font's style. Possible values include '`normal`', `'italic'`. Defaults to `'normal'`.
+         */
+        style: string;
+        /**
+         * @name Two.Text#weight
+         * @property {Number} - A number at intervals of 100 to describe the font's weight. This compatibility varies with the typeface's variant weights. Larger values are bolder. Smaller values are thinner. Defaults to `'500'`.
+         */
+        weight: number;
+        /**
+         * @name Two.Text#decoration
+         * @property {String} - String to delineate whether text should be decorated with for instance an `'underline'`. Defaults to `'none'`.
+         */
+        decoration: string;
+        /**
+         * @name Two.Text#fill
+         * @property {(String|Gradient|Texture)} - The value of what the text object should be filled in with.
+         * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
+         */
+        fill: string|Gradient|Texture;
+        /**
+         * @name Two.Text#stroke
+         * @property {(String|Gradient|Texture)} - The value of what the text object should be filled in with.
+         * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
+         */
+        stroke: string|Gradient|Texture;
+        /**
+         * @name Two.Text#linewidth
+         * @property {Number} - The thickness in pixels of the stroke.
+         */
+        linewidth: number;
+        /**
+         * @name Two.Text#opacity
+         * @property {Number} - The opaqueness of the text object.
+         * @nota-bene Can be used in conjunction with CSS Colors that have an alpha value.
+         */
+        opacity: number;
+        /**
+         * @name Two.Text#visible
+         * @property {Boolean} - Display the text object or not.
+         * @nota-bene For {@link Two.CanvasRenderer} and {@link Two.WebGLRenderer} when set to false all updating is disabled improving performance dramatically with many objects in the scene.
+         */
+        visible: boolean;
+        /**
+         * @name Two.Text#mask
+         * @property {Shape} - The shape whose alpha property becomes a clipping area for the text.
+         * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
+         */
+        mask: any;
+        /**
+         * @name Two.Text#clip
+         * @property {Shape} - Object to define clipping area.
+         * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
+         */
+        clip: boolean;
         /**
          * @name Two.Text#dashes
          * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
          * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
          */
-        dashes: any[];
-        /**
-         * @name Two.Text#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Text}
-         * @description Create a new instance of {@link Two.Text} with the same properties of the current text object.
-         */
-        clone(parent?: Two.Group): Two.Text;
+        dashes: number[];
         /**
          * @name Two.Text#toObject
          * @function
@@ -3499,15 +3140,12 @@ declare module "src/text" {
          * @description Short hand method to set fill to `transparent`.
          */
         noFill(): Text;
-        fill: string;
         /**
          * @name Two.Text#noStroke
          * @function
          * @description Short hand method to set stroke to `transparent`.
          */
         noStroke(): Text;
-        stroke: any;
-        linewidth: any;
         /**
          * @name Two.Text#getBoundingClientRect
          * @function
@@ -3516,17 +3154,12 @@ declare module "src/text" {
          * @description Return an object with top, left, right, bottom, width, and height parameters of the text object.
          */
         getBoundingClientRect(shallow?: boolean): any;
-        /**
-         * @name Two.Text#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
-        _flagClassName: boolean;
     }
+    import { Shape } from "two.js/src/shape";
+    import { Gradient } from "two.js/src/effects/gradient";
+    import { Texture } from "two.js/src/effects/texture";
 }
-declare module "src/utils/interpret-svg" {
+declare module "two.js/src/utils/interpret-svg" {
     /**
      * @name Two.Utils.read
      * @property {Object} read - A map of functions to read any number of SVG node types and create Two.js equivalents of them. Primarily used by the {@link Two#interpret} method.
@@ -3539,25 +3172,30 @@ declare module "src/utils/interpret-svg" {
         polygon: (node: any, parentStyles: any) => Path;
         polyline: (node: any, parentStyles: any) => any;
         path: (node: any, parentStyles: any) => Path;
-        circle: (node: any, parentStyles: any) => any;
-        ellipse: (node: any, parentStyles: any) => any;
-        rect: (node: any, parentStyles: any) => any;
-        'rounded-rect': (node: any, parentStyles: any) => any;
-        line: (node: any, parentStyles: any) => any;
+        circle: (node: any, parentStyles: any) => Circle;
+        ellipse: (node: any, parentStyles: any) => Ellipse;
+        rect: (node: any, parentStyles: any) => Rectangle | RoundedRectangle;
+        'rounded-rect': (node: any, parentStyles: any) => RoundedRectangle;
+        line: (node: any, parentStyles: any) => Line;
         lineargradient: (node: any, parentStyles: any) => LinearGradient;
         radialgradient: (node: any, parentStyles: any) => RadialGradient;
         text: (node: any, parentStyles: any) => Text;
         clippath: (node: any, parentStyles: any) => any;
         image: (node: any, parentStyles: any) => Sprite;
     };
-    import { Group } from "src/group";
-    import { Path } from "src/path";
-    import { LinearGradient } from "src/effects/linear-gradient";
-    import { RadialGradient } from "src/effects/radial-gradient";
-    import { Text } from "src/text";
-    import { Sprite } from "src/effects/sprite";
+    import { Group } from "two.js/src/group";
+    import { Path } from "two.js/src/path";
+    import { Circle } from "two.js/src/shapes/circle";
+    import { Ellipse } from "two.js/src/shapes/ellipse";
+    import { Rectangle } from "two.js/src/shapes/rectangle";
+    import { RoundedRectangle } from "two.js/src/shapes/rounded-rectangle";
+    import { Line } from "two.js/src/shapes/line";
+    import { LinearGradient } from "two.js/src/effects/linear-gradient";
+    import { RadialGradient } from "two.js/src/effects/radial-gradient";
+    import { Text } from "two.js/src/text";
+    import { Sprite } from "two.js/src/effects/sprite";
 }
-declare module "src/utils/xhr" {
+declare module "two.js/src/utils/xhr" {
     /**
      * @name Two.Utils.xhr
      * @function
@@ -3568,29 +3206,23 @@ declare module "src/utils/xhr" {
      */
     export function xhr(path: string, callback: Function): XMLHttpRequest;
 }
-declare module "src/effects/image-sequence" {
+declare module "two.js/src/effects/image-sequence" {
     /**
      * @name Two.ImageSequence
      * @class
-     * @extends Two.Rectangle
-     * @param {String|String[]|Two.Texture|Two.Texture[]} paths - A list of URLs or {@link Two.Texture}s.
+
+     * @param {String|String[]|Texture|Texture[]} paths - A list of URLs or {@link Two.Texture}s.
      * @param {Number} [ox=0] - The initial `x` position of the Two.ImageSequence.
      * @param {Number} [oy=0] - The initial `y` position of the Two.ImageSequence.
      * @param {Number} [frameRate=30] - The frame rate at which the images should playback at.
      * @description A convenient package to display still or animated images organized as a series of still images.
      */
-    export class ImageSequence {
-        /**
-         * @name Two.ImageSequence.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.ImageSequence}.
-         */
-        static Properties: string[];
+    export class ImageSequence extends Rectangle {
         /**
          * @name Two.ImageSequence.DefaultFrameRate
          * @property The default frame rate that {@link Two.ImageSequence#frameRate} is set to when instantiated.
          */
         static DefaultFrameRate: number;
-        constructor(paths: any, ox: any, oy: any, frameRate: any);
         /**
          * @name Two.ImageSequence#_flagTextures
          * @private
@@ -3669,14 +3301,7 @@ declare module "src/effects/image-sequence" {
          * @see {@link Two.ImageSequence#frameRate}
          */
         private _frameRate;
-        /**
-         * @name Two.ImageSequence#_origin
-         * @private
-         * @see {@link Two.ImageSequence#origin}
-         */
-        private _origin;
         textures: any[];
-        origin: Vector;
         frameRate: number;
         /**
          * @name Two.ImageSequence#index
@@ -3705,48 +3330,14 @@ declare module "src/effects/image-sequence" {
          * @description Halt animation playback of a {@link Two.ImageSequence} and set the current frame back to the first frame.
          */
         stop(): ImageSequence;
-        /**
-         * @name Two.ImageSequence#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.ImageSequence}
-         * @description Create a new instance of {@link Two.ImageSequence} with the same properties of the current image sequence.
-         */
-        clone(parent?: Two.Group): Two.ImageSequence;
-        /**
-         * @name Two.ImageSequence#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
-        /**
-         * @name Two.ImageSequence#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        width: any;
-        height: any;
-        fill: any;
-        /**
-         * @name Two.ImageSequence#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
     }
-    import { Vector } from "src/vector";
+    import { Rectangle } from "two.js/src/shapes/rectangle";
 }
-declare module "src/shapes/arc-segment" {
+declare module "two.js/src/shapes/arc-segment" {
     /**
      * @name Two.ArcSegment
      * @class
-     * @extends Two.Path
+
      * @param {Number} [x=0] - The x position of the arc segment.
      * @param {Number} [y=0] - The y position of the arc segment.
      * @param {Number} [innerRadius=0] - The inner radius value of the arc segment.
@@ -3755,13 +3346,8 @@ declare module "src/shapes/arc-segment" {
      * @param {Number} [endAngle=6.2831] - The end angle of the arc segment in Number.
      * @param {Number} [resolution=24] - The number of vertices used to construct the arc segment.
      */
-    export class ArcSegment {
-        /**
-         * @name Two.ArcSegment.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.ArcSegment}.
-         */
-        static Properties: string[];
-        constructor(x: any, y: any, ir: any, or: any, sa: any, ea: any, res: any);
+    export class ArcSegment extends Path {
+        constructor(ox?: number, oy?: number, ir?: number, or?: number, sa?: number, ea?: number, res?: number);
         /**
          * @name Two.ArcSegment#_flagStartAngle
          * @private
@@ -3814,70 +3400,40 @@ declare module "src/shapes/arc-segment" {
         outerRadius: number;
         startAngle: number;
         endAngle: number;
-        /**
-         * @name Two.ArcSegment#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.ArcSegment#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
-        /**
-         * @name Two.ArcSegment#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.ArcSegment}
-         * @description Create a new instance of {@link Two.ArcSegment} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.ArcSegment;
-        /**
-         * @name Two.ArcSegment#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
     }
+    import { Path } from "two.js/src/path";
 }
-declare module "src/shapes/points" {
+declare module "two.js/src/shapes/points" {
     /**
      * @name Two.Points
      * @class
-     * @extends Two.Shape
-     * @param {Two.Vector[]} [vertices] - A list of {@link Two.Vector}s that represent the order and coordinates to construct a rendered set of points.
+
+     * @param {Vector[]} [vertices] - A list of {@link Two.Vector}s that represent the order and coordinates to construct a rendered set of points.
      * @description This is a primary primitive class for quickly and easily drawing points in Two.js. Unless specified methods return their instance of `Two.Points` for the purpose of chaining.
      */
-    export class Points {
+    export class Points extends Shape {
         static Properties: string[];
-        constructor(vertices: any);
-        _flagVertices: boolean;
-        _flagLength: boolean;
-        _flagFill: boolean;
-        _flagStroke: boolean;
-        _flagLinewidth: boolean;
-        _flagOpacity: boolean;
-        _flagVisible: boolean;
-        _flagSize: boolean;
-        _flagSizeAttenuation: boolean;
-        _length: number;
-        _fill: string;
-        _stroke: string;
-        _linewidth: number;
-        _opacity: number;
-        _visible: boolean;
-        _size: number;
-        _sizeAttenuation: boolean;
-        _beginning: number;
-        _ending: number;
-        _dashes: any;
+        constructor(vertices?: any[]);
+        private _flagVertices;
+        private _flagLength;
+        private _flagFill;
+        private _flagStroke;
+        private _flagLinewidth;
+        private _flagOpacity;
+        private _flagVisible;
+        private _flagSize;
+        private _flagSizeAttenuation;
+        private _length;
+        private _fill;
+        private _stroke;
+        private _linewidth;
+        private _opacity;
+        private _visible;
+        private _size;
+        private _sizeAttenuation;
+        private _beginning;
+        private _ending;
+        private _dashes;
         /**
          * @name Two.Points#sizeAttenuation
          * @property {Boolean} - Boolean dictating whether Two.js should scale the size of the points based on its matrix hierarcy.
@@ -3898,16 +3454,16 @@ declare module "src/shapes/points" {
         ending: number;
         /**
          * @name Two.Points#fill
-         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be filled in with.
+         * @property {(String|Gradient|Texture)} - The value of what the path should be filled in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        fill: string;
+        fill: string|Gradient|Texture;
         /**
          * @name Two.Points#stroke
-         * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be outlined in with.
+         * @property {(String|Gradient|Texture)} - The value of what the path should be outlined in with.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
          */
-        stroke: string;
+        stroke: string|Gradient|Texture;
         /**
          * @name Two.Points#className
          * @property {String} - A class to be applied to the element to be compatible with CSS styling.
@@ -3922,7 +3478,7 @@ declare module "src/shapes/points" {
         visible: boolean;
         /**
          * @name Two.Points#vertices
-         * @property {Two.Vector[]} - An ordered list of vector points for rendering points.
+         * @property {Vector[]} - An ordered list of vector points for rendering points.
          * @description A list of {@link Two.Vector} objects that consist of which coordinates to draw points at.
          * @nota-bene The array when manipulating is actually a {@link Two.Collection}.
          */
@@ -3933,15 +3489,7 @@ declare module "src/shapes/points" {
          * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
          * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
          */
-        dashes: any[];
-        /**
-         * @name Two.Points#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Points}
-         * @description Create a new instance of {@link Two.Points} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.Points;
+        dashes: number[];
         /**
          * @name Two.Points#toObject
          * @function
@@ -3954,25 +3502,25 @@ declare module "src/shapes/points" {
          * @function
          * @description Short hand method to set fill to `transparent`.
          */
-        noFill: () => Path;
+        noFill: () => Points;
         /**
          * @name Two.Points#noStroke
          * @function
          * @description Short hand method to set stroke to `transparent`.
          */
-        noStroke: () => Path;
+        noStroke: () => Points;
         /**
          * @name Two.Points#corner
          * @function
          * @description Orient the vertices of the shape to the upper left-hand corner of the points object.
          */
-        corner: () => Path;
+        corner: () => Points;
         /**
          * @name Two.Points#center
          * @function
          * @description Orient the vertices of the shape to the center of the points object.
          */
-        center: () => Path;
+        center: () => Points;
         /**
          * @name Two.Points#getBoundingClientRect
          * @function
@@ -3997,42 +3545,22 @@ declare module "src/shapes/points" {
          * @description Recalculate the {@link Two.Points#length} value.
          */
         private _updateLength;
-        /**
-         * @name Two.Points#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.Points#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
     }
-    import { Path } from "src/path";
+    import { Shape } from "two.js/src/shape";
+    import { Gradient } from "two.js/src/effects/gradient";
+    import { Texture } from "two.js/src/effects/texture";
 }
-declare module "src/shapes/polygon" {
+declare module "two.js/src/shapes/polygon" {
     /**
      * @name Two.Polygon
      * @class
-     * @extends Two.Path
+
      * @param {Number} [x=0] - The x position of the polygon.
      * @param {Number} [y=0] - The y position of the polygon.
      * @param {Number} [radius=0] - The radius value of the polygon.
      * @param {Number} [sides=12] - The number of vertices used to construct the polygon.
      */
-    export class Polygon {
-        /**
-         * @name Two.Polygon.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.Polygon}.
-         */
-        static Properties: string[];
-        constructor(x: any, y: any, radius: any, sides: any);
+    export class Polygon extends Path {
         /**
          * @name Two.Polygon#_flagWidth
          * @private
@@ -4052,12 +3580,6 @@ declare module "src/shapes/polygon" {
          */
         private _flagSides;
         /**
-         * @name Two.Polygon#_radius
-         * @private
-         * @see {@link Two.Polygon#radius}
-         */
-        private _radius;
-        /**
          * @name Two.Polygon#_width
          * @private
          * @see {@link Two.Polygon#width}
@@ -4075,61 +3597,27 @@ declare module "src/shapes/polygon" {
          * @see {@link Two.Polygon#sides}
          */
         private _sides;
+        constructor(x?: number, y?: number, radius?: number, sides?: number);
         closed: boolean;
-        automatic: boolean;
-        radius: number;
+        width: number;
+        height: number;
         sides: number;
-        /**
-         * @name Two.Polygon#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.Polygon#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
-        /**
-         * @name Two.Polygon#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Polygon}
-         * @description Create a new instance of {@link Two.Polygon} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.Polygon;
-        /**
-         * @name Two.Polygon#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
     }
+    import { Path } from "two.js/src/path";
 }
-declare module "src/shapes/star" {
+declare module "two.js/src/shapes/star" {
     /**
      * @name Two.Star
      * @class
-     * @extends Two.Path
+
      * @param {Number} [x=0] - The x position of the star.
      * @param {Number} [y=0] - The y position of the star.
      * @param {Number} [innerRadius=0] - The inner radius value of the star.
      * @param {Number} [outerRadius=0] - The outer radius value of the star.
      * @param {Number} [sides=5] - The number of sides used to construct the star.
      */
-    export class Star {
-        /**
-         * @name Two.Star.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.Star}.
-         */
-        static Properties: string[];
-        constructor(x: any, y: any, innerRadius: any, outerRadius: any, sides: any, ...args: any[]);
+    export class Star extends Path {
+        constructor(ox?: number, oy?: number, ir?: number, or?: number, sides?: number);
         /**
          * @name Two.Star#_flagInnerRadius
          * @private
@@ -4167,53 +3655,22 @@ declare module "src/shapes/star" {
          */
         private _sides;
         closed: boolean;
-        automatic: boolean;
         innerRadius: number;
         outerRadius: number;
         sides: number;
-        /**
-         * @name Two.Star#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.Star#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
-        /**
-         * @name Two.Star#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.Star}
-         * @description Create a new instance of {@link Two.Star} with the same properties of the current path.
-         */
-        clone(parent?: Two.Group): Two.Star;
-        /**
-         * @name Two.Star#toObject
-         * @function
-         * @returns {Object}
-         * @description Return a JSON compatible plain object that represents the path.
-         */
-        toObject(): any;
     }
+    import { Path } from "two.js/src/path";
 }
-declare module "src/renderers/svg" {
+declare module "two.js/src/renderers/svg" {
     /**
      * @name Two.SVGRenderer
      * @class
-     * @extends Two.Events
+
      * @param {Object} [parameters] - This object is inherited when constructing a new instance of {@link Two}.
      * @param {Element} [parameters.domElement] - The `<svg />` to draw to. If none given a new one will be constructed.
      * @description This class is used by {@link Two} when constructing with `type` of `Two.Types.svg` (the default type). It takes Two.js' scenegraph and renders it to a `<svg />`.
      */
-    export class Renderer {
+    export class Renderer extends Events {
         /**
          * @name Two.SVGRenderer.Utils
          * @property {Object} - A massive object filled with utility functions and properties to render Two.js objects to a `<svg />`.
@@ -4227,7 +3684,7 @@ declare module "src/renderers/svg" {
                 center: string;
                 right: string;
             };
-            createElement: (name: any, attrs: any) => Element;
+            createElement: (name: any, attrs: any) => SVGElement;
             setAttributes: (elem: any, attrs: any) => any;
             removeAttributes: (elem: any, attrs: any) => any;
             toString: (points: any, closed: any) => string;
@@ -4259,7 +3716,7 @@ declare module "src/renderers/svg" {
                 render: (domElement: any, silent: any) => any;
             };
         };
-        constructor(params: any);
+        constructor(params?: any);
         /**
          * @name Two.SVGRenderer#domElement
          * @property {Element} - The `<svg />` associated with the Two.js scene.
@@ -4267,14 +3724,14 @@ declare module "src/renderers/svg" {
         domElement: any;
         /**
          * @name Two.SVGRenderer#scene
-         * @property {Two.Group} - The root group of the scenegraph.
+         * @property {Group} - The root group of the scenegraph.
          */
         scene: Group;
         /**
          * @name Two.SVGRenderer#defs
          * @property {SvgDefintionsElement} - The `<defs />` to apply gradients, patterns, and bitmap imagery.
          */
-        defs: Element;
+        defs: SVGDefsElement;
         /**
          * @name Two.SVGRenderer#setSize
          * @function
@@ -4293,9 +3750,10 @@ declare module "src/renderers/svg" {
          */
         render(): Renderer;
     }
-    import { Group } from "src/group";
+    import { Events } from "two.js/src/events";
+    import { Group } from "two.js/src/group";
 }
-declare module "src/utils/shaders" {
+declare module "two.js/src/utils/shaders" {
     export namespace shaders {
         function create(gl: any, source: any, type: any): any;
         namespace types {
@@ -4316,11 +3774,11 @@ declare module "src/utils/shaders" {
         }
     }
 }
-declare module "src/renderers/webgl" {
+declare module "two.js/src/renderers/webgl" {
     /**
      * @name Two.WebGLRenderer
      * @class
-     * @extends Two.Events
+
      * @param {Object} [parameters] - This object is inherited when constructing a new instance of {@link Two}.
      * @param {Element} [parameters.domElement] - The `<canvas />` to draw to. If none given a new one will be constructed.
      * @param {HTMLCanvasElement} [parameters.offscreenElement] - The offscreen two dimensional `<canvas />` to render each element on WebGL texture updates.
@@ -4328,7 +3786,7 @@ declare module "src/renderers/webgl" {
      * @description This class is used by {@link Two} when constructing with `type` of `Two.Types.webgl`. It takes Two.js' scenegraph and renders it to a `<canvas />` through the WebGL api.
      * @see {@link https://www.khronos.org/registry/webgl/specs/latest/1.0/}
      */
-    export class Renderer {
+    export class Renderer extends Events {
         /**
          * @name Two.WebGLRenderer.Utils
          * @property {Object} - A massive object filled with utility functions and properties to render Two.js objects to a `<canvas />` through the WebGL API.
@@ -4382,15 +3840,15 @@ declare module "src/renderers/webgl" {
             };
             TextureRegistry: Registry;
         };
-        constructor(params: any);
+        constructor(params?: any);
         /**
          * @name Two.WebGLRenderer#domElement
          * @property {Element} - The `<canvas />` associated with the Two.js scene.
          */
-        domElement: any;
+        domElement: HTMLCanvasElement;
         /**
          * @name Two.WebGLRenderer#scene
-         * @property {Two.Group} - The root group of the scenegraph.
+         * @property {Group} - The root group of the scenegraph.
          */
         scene: Group;
         _renderer: {
@@ -4443,19 +3901,20 @@ declare module "src/renderers/webgl" {
          */
         render(): Renderer;
     }
-    import { Group } from "src/group";
-    import { Matrix } from "src/matrix";
-    import { Registry } from "src/registry";
+    import { Events } from "two.js/src/events";
+    import { Group } from "two.js/src/group";
+    import { Matrix } from "two.js/src/matrix";
+    import { Registry } from "two.js/src/registry";
 }
-declare module "src/two" {
+declare module "two.js" {
     /**
      * @name Two
      * @class
      * @global
-     * @extends Two.Events
+
      * @param {Object} [options]
      * @param {Boolean} [options.fullscreen=false] - Set to `true` to automatically make the stage adapt to the width and height of the parent document. This parameter overrides `width` and `height` parameters if set to `true`. This overrides `options.fitted` as well.
-     * @param {Boolean} [options.fitted=false] - Set to `true` to automatically make the stage adapt to the width and height of the parent element. This parameter overrides `width` and `height` parameters if set to `true`.
+     * @param {Boolean} [options.fitted=false] = Set to `true` to automatically make the stage adapt to the width and height of the parent element. This parameter overrides `width` and `height` parameters if set to `true`.
      * @param {Number} [options.width=640] - The width of the stage on construction. This can be set at a later time.
      * @param {Number} [options.height=480] - The height of the stage on construction. This can be set at a later time.
      * @param {String} [options.type=Two.Types.svg] - The type of renderer to setup drawing with. See {@link Two.Types} for available options.
@@ -4549,12 +4008,20 @@ declare module "src/two" {
         };
         /**
          * @name Two.Utils
-         * @property {Object} Utils - A massive object filled with utility functions and properties.
-         * @property {Object} Two.Utils.read - A collection of SVG parsing functions indexed by element name.
-         * @property {Function} Two.Utils.read.path - Parse SVG path element or `d` attribute string.
+         * @property {Object} - A massive object filled with utility functions and properties.
          */
         static Utils: any;
-        constructor(options: any);
+        constructor(options?: {
+          fullscreen?: boolean,
+          fitted?: boolean,
+          autostart?: boolean,
+          width?: number,
+          height?: number,
+          type?: string,
+          domElement?: HTMLElement,
+          overdraw?: boolean,
+          smoothing?: boolean
+        });
         /**
          * @private
          */
@@ -4578,14 +4045,14 @@ declare module "src/two" {
         type: string;
         /**
          * @name Two#renderer
-         * @property {(Two.SVGRenderer|Two.CanvasRenderer|Two.WebGLRenderer)} - The instantiated rendering class for the instance. For a list of possible rendering types check out Two.Types.
+         * @property {(Two.SVGRenderer|CanvasRenderer|WebGLRenderer)} - The instantiated rendering class for the instance. For a list of possible rendering types check out Two.Types.
          */
         renderer: any;
         /**
          * @name Two#scene
-         * @property {Two.Group} - The base level {@link Two.Group} which houses all objects for the instance. Because it is a {@link Two.Group} transformations can be applied to it that will affect all objects in the instance. This is handy as a makeshift inverted camera.
+         * @property {Group} - The base level {@link Two.Group} which houses all objects for the instance. Because it is a {@link Two.Group} transformations can be applied to it that will affect all objects in the instance. This is handy as a makeshift inverted camera.
          */
-        scene: any;
+        scene: Group;
         /**
          * @name Two#width
          * @property {Number} - The width of the instance's dom element.
@@ -4618,11 +4085,11 @@ declare module "src/two" {
          * @param {Element} elem - The DOM element to append the Two.js stage to.
          * @description Shorthand method to append your instance of Two.js to the `document`.
          */
-        appendTo(elem: Element): Two;
+        appendTo(elem: HTMLElement): Two;
         /**
          * @name Two#play
          * @function
-         * @fires play
+         * @fires Two.Events.Types.play event
          * @description Call to start an internal animation loop.
          * @nota-bene This function initiates a `requestAnimationFrame` loop.
          */
@@ -4630,7 +4097,7 @@ declare module "src/two" {
         /**
          * @name Two#pause
          * @function
-         * @fires pause
+         * @fires Two.Events.Types.pause event
          * @description Call to stop the internal animation loop for a specific instance of Two.js.
          */
         pause(): any;
@@ -4646,7 +4113,7 @@ declare module "src/two" {
         /**
          * @name Two#update
          * @function
-         * @fires update
+         * @fires Two.Events.Types.update event
          * @description Update positions and calculations in one pass before rendering. Then render to the canvas.
          * @nota-bene This function is called automatically if using {@link Two#play} or the `autostart` parameter in construction.
          */
@@ -4662,17 +4129,31 @@ declare module "src/two" {
         /**
          * @name Two#add
          * @function
-         * @param {(Two.Shape[]|...Two.Shape)} [objects] - An array of Two.js objects. Alternatively can add objects as individual arguments.
+         * @param {TwoElement[]} [objects] - An array of Two.js objects. Alternatively can add objects as individual arguments.
          * @description A shorthand method to add specific Two.js objects to the scene.
          */
-        add(objects: any, ...args: any[]): Two;
+        add(objects: TwoElement): Two;
+        /**
+         * @name Two#add
+         * @function
+         * @param {...TwoElement} [args] - Alternatively pass each shape as an argument
+         * @description A shorthand method to add specific Two.js objects to the scene.
+         */
+        add(...args: TwoElement[]): Two;
         /**
          * @name Two#remove
          * @function
-         * @param {(Two.Shape[]|...Two.Shape)} [objects] - An array of Two.js objects.
+         * @param {TwoElement[]} [objects] - An array of Two.js objects.
          * @description A shorthand method to remove specific Two.js objects from the scene.
          */
-        remove(objects: any, ...args: any[]): Two;
+        remove(objects: TwoElement): Two;
+        /**
+         * @name Two#remove
+         * @function
+         * @param {...TwoElement} [args] - Alternatively pass each shape as an argument
+         * @description A shorthand method to remove specific Two.js objects from the scene.
+         */
+        remove(...args: TwoElement[]): Two;
         /**
          * @name Two#clear
          * @function
@@ -4686,10 +4167,10 @@ declare module "src/two" {
          * @param {Number} y1
          * @param {Number} x2
          * @param {Number} y2
-         * @returns {Two.Line}
+         * @returns {Line}
          * @description Creates a Two.js line and adds it to the scene.
          */
-        makeLine(x1: number, y1: number, x2: number, y2: number): typeof Line;
+        makeLine(x1: number, y1: number, x2: number, y2: number): Line;
         /**
          * @name Two#makeArrow
          * @function
@@ -4697,10 +4178,10 @@ declare module "src/two" {
          * @param {Number} y1
          * @param {Number} x2
          * @param {Number} y2
-         * @returns {Two.Path}
+         * @returns {Path}
          * @description Creates a Two.js arrow and adds it to the scene.
          */
-        makeArrow(x1: number, y1: number, x2: number, y2: number, size: any): typeof Path;
+        makeArrow(x1: number, y1: number, x2: number, y2: number, size: number): Path;
         /**
          * @name Two#makeRectangle
          * @function
@@ -4708,10 +4189,10 @@ declare module "src/two" {
          * @param {Number} y
          * @param {Number} width
          * @param {Number} height
-         * @returns {Two.Rectangle}
+         * @returns {Rectangle}
          * @description Creates a Two.js rectangle and adds it to the scene.
          */
-        makeRectangle(x: number, y: number, width: number, height: number): typeof Rectangle;
+        makeRectangle(x: number, y: number, width: number, height: number): Rectangle;
         /**
          * @name Two#makeRoundedRectangle
          * @function
@@ -4720,10 +4201,10 @@ declare module "src/two" {
          * @param {Number} width
          * @param {Number} height
          * @param {Number} sides
-         * @returns {Two.Rectangle}
+         * @returns {Rectangle}
          * @description Creates a Two.js rounded rectangle and adds it to the scene.
          */
-        makeRoundedRectangle(x: number, y: number, width: number, height: number, sides: number): typeof Rectangle;
+        makeRoundedRectangle(x: number, y: number, width: number, height: number, sides: number): Rectangle;
         /**
          * @name Two#makeCircle
          * @function
@@ -4731,10 +4212,10 @@ declare module "src/two" {
          * @param {Number} y
          * @param {Number} radius
          * @param {Number} [resolution=4]
-         * @returns {Two.Circle}
+         * @returns {Circle}
          * @description Creates a Two.js circle and adds it to the scene.
          */
-        makeCircle(x: number, y: number, radius: number, resolution?: number): typeof Circle;
+        makeCircle(x: number, y: number, radius: number, resolution?: number): Circle;
         /**
          * @name Two#makeEllipse
          * @function
@@ -4743,10 +4224,10 @@ declare module "src/two" {
          * @param {Number} rx
          * @param {Number} ry
          * @param {Number} [resolution=4]
-         * @returns {Two.Ellipse}
+         * @returns {Ellipse}
          * @description Creates a Two.js ellipse and adds it to the scene.
          */
-        makeEllipse(x: number, y: number, rx: number, ry: number, resolution?: number): typeof Ellipse;
+        makeEllipse(x: number, y: number, rx: number, ry: number, resolution?: number): Ellipse;
         /**
          * @name Two#makeStar
          * @function
@@ -4755,20 +4236,28 @@ declare module "src/two" {
          * @param {Number} outerRadius
          * @param {Number} innerRadius
          * @param {Number} sides
-         * @returns {Two.Star}
+         * @returns {Star}
          * @description Creates a Two.js star and adds it to the scene.
          */
-        makeStar(x: number, y: number, outerRadius: number, innerRadius: number, sides: number): typeof Star;
+        makeStar(x: any, y: any, outerRadius: number, innerRadius: number, sides: number): Star;
         /**
          * @name Two#makeCurve
          * @function
-         * @param {Two.Anchor[]} [points] - An array of {@link Two.Anchor} points.
-         * @param {...Number} - Alternatively you can pass alternating `x` / `y` coordinate values as individual arguments. These will be combined into {@link Two.Anchor}s for use in the path.
-         * @returns {Two.Path} - Where `path.curved` is set to `true`.
+         * @param {Anchor[]} [points] - An array of {@link Two.Anchor} points.
+         * @returns {Path} - Where `path.curved` is set to `true`.
          * @description Creates a Two.js path that is curved and adds it to the scene.
          * @nota-bene In either case of passing an array or passing numbered arguments the last argument is an optional `Boolean` that defines whether the path should be open or closed.
          */
-        makeCurve(points?: (typeof Anchor)[], ...args: any[]): typeof Path;
+        makeCurve(points?: Anchor[]): Path;
+        /**
+         * @name Two#makeCurve
+         * @function
+         * @param {...Number} [args] - Alternatively you can pass alternating `x` / `y` coordinate values as individual arguments. These will be combined into {@link Two.Anchor}s for use in the path.
+         * @returns {Path} - Where `path.curved` is set to `true`.
+         * @description Creates a Two.js path that is curved and adds it to the scene.
+         * @nota-bene In either case of passing an array or passing numbered arguments the last argument is an optional `Boolean` that defines whether the path should be open or closed.
+         */
+        makeCurve(...args: number[]): Path;
         /**
          * @name Two#makePolygon
          * @function
@@ -4776,10 +4265,10 @@ declare module "src/two" {
          * @param {Number} y
          * @param {Number} radius
          * @param {Number} sides
-         * @returns {Two.Polygon}
+         * @returns {Polygon}
          * @description Creates a Two.js polygon and adds it to the scene.
          */
-        makePolygon(x: number, y: number, radius: number, sides: number): typeof Polygon;
+        makePolygon(x: number, y: number, radius: number, sides: number): Polygon;
         /**
          * @name Two#makeArcSegment
          * @function
@@ -4790,28 +4279,43 @@ declare module "src/two" {
          * @param {Number} startAngle
          * @param {Number} endAngle
          * @param {Number} [resolution=Two.Resolution] - The number of vertices that should comprise the arc segment.
-         * @returns {Two.ArcSegment}
+         * @returns {ArcSegment}
          */
-        makeArcSegment(x: number, y: number, innerRadius: number, outerRadius: number, startAngle: number, endAngle: number, resolution?: number): typeof ArcSegment;
+        makeArcSegment(x: number, y: number, innerRadius: number, outerRadius: number, startAngle: number, endAngle: number, resolution?: number): ArcSegment;
         /**
          * @name Two#makePoints
          * @function
-         * @param {Two.Vector[]} [points] - An array of {@link Two.Vector} points
-         * @param {...Number} - Alternatively you can pass alternating `x` / `y` coordinate values as individual agrguments. These will be combined into {@link Two.Vector}s for use in the points object.
-         * @returns {Two.Points}
+         * @param {Vector[]} [points] - An array of {@link Two.Vector} points
+         * @returns {Points}
          * @description Creates a Two.js points object and adds it to the current scene.
          */
-        makePoints(p: any, ...args: any[]): typeof Points;
+        makePoints(points?: Vector[]): Points;
+        /**
+         * @name Two#makePoints
+         * @function
+         * @param {...Number} [args] - Alternatively you can pass alternating `x` / `y` coordinate values as individual agrguments. These will be combined into {@link Two.Vector}s for use in the points object.
+         * @returns {Points}
+         * @description Creates a Two.js points object and adds it to the current scene.
+         */
+        makePoints(...args: number[]): Points;
         /**
          * @name Two#makePath
          * @function
-         * @param {Two.Anchor[]} [points] - An array of {@link Two.Anchor} points
-         * @param {...Number} - Alternatively you can pass alternating `x` / `y` coordinate values as individual arguments. These will be combined into {@link Two.Anchor}s for use in the path.
-         * @returns {Two.Path}
+         * @param {Anchor[]} [points] - An array of {@link Two.Anchor} points
+         * @returns {Path}
          * @description Creates a Two.js path and adds it to the scene.
          * @nota-bene In either case of passing an array or passing numbered arguments the last argument is an optional `Boolean` that defines whether the path should be open or closed.
          */
-        makePath(p: any, ...args: any[]): typeof Path;
+        makePath(points?: Anchor[]): Path;
+        /**
+         * @name Two#makePath
+         * @function
+         * @param {...Number} [args] - Alternatively you can pass alternating `x` / `y` coordinate values as individual arguments. These will be combined into {@link Two.Anchor}s for use in the path.
+         * @returns {Path}
+         * @description Creates a Two.js path and adds it to the scene.
+         * @nota-bene In either case of passing an array or passing numbered arguments the last argument is an optional `Boolean` that defines whether the path should be open or closed.
+         */
+        makePath(...args: number[]): Path;
         /**
          * @name Two#makeText
          * @function
@@ -4819,10 +4323,10 @@ declare module "src/two" {
          * @param {Number} x
          * @param {Number} y
          * @param {Object} [styles] - An object to describe any of the {@link Two.Text.Properties} including `fill`, `stroke`, `linewidth`, `family`, `alignment`, `leading`, `opacity`, etc..
-         * @returns {Two.Text}
+         * @returns {Text}
          * @description Creates a Two.js text object and adds it to the scene.
          */
-        makeText(message: string, x: number, y: number, styles?: any): typeof Text;
+        makeText(message: string, x: number, y: number, styles?: any): Text;
         /**
          * @name Two#makeLinearGradient
          * @function
@@ -4830,184 +4334,133 @@ declare module "src/two" {
          * @param {Number} y1
          * @param {Number} x2
          * @param {Number} y2
-         * @param {...Two.Stop} args - Any number of color stops sometimes referred to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
-         * @returns {Two.LinearGradient}
-         * @description Creates a Two.js linear gradient and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
+         * @param {...Stop} args - Any number of color stops sometimes reffered to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
+         * @returns {LinearGradient}
+         * @description Creates a Two.js linear gradient and ads it to the scene. In the case of an effect it's added to an invisible "definitions" group.
          */
-        makeLinearGradient(x1: number, y1: number, x2: number, y2: number, ...args: any[]): typeof LinearGradient;
+        makeLinearGradient(x1: number, y1: number, x2: number, y2: number, ...args: Stop[]): LinearGradient;
         /**
          * @name Two#makeRadialGradient
          * @function
          * @param {Number} x1
          * @param {Number} y1
          * @param {Number} radius
-         * @param {...Two.Stop} args - Any number of color stops sometimes referred to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
-         * @returns {Two.RadialGradient}
-         * @description Creates a Two.js linear-gradient object and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
+         * @param {...Stop} args - Any number of color stops sometimes reffered to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
+         * @returns {RadialGradient}
+         * @description Creates a Two.js linear-gradient object and ads it to the scene. In the case of an effect it's added to an invisible "definitions" group.
          */
-        makeRadialGradient(x1: number, y1: number, radius: number, ...args: any[]): typeof RadialGradient;
+        makeRadialGradient(x1: number, y1: number, radius: number, ...args: Stop[]): RadialGradient;
         /**
          * @name Two#makeSprite
          * @function
-         * @param {(String|Two.Texture)} pathOrTexture - The URL path to an image or an already created {@link Two.Texture}.
+         * @param {(String|Texture)} pathOrTexture - The URL path to an image or an already created {@link Two.Texture}.
          * @param {Number} x
          * @param {Number} y
          * @param {Number} [columns=1]
          * @param {Number} [rows=1]
          * @param {Number} [frameRate=0]
          * @param {Boolean} [autostart=false]
-         * @returns {Two.Sprite}
+         * @returns {Sprite}
          * @description Creates a Two.js sprite object and adds it to the scene. Sprites can be used for still images as well as animations.
          */
-        makeSprite(pathOrTexture: (string | typeof Texture), x: number, y: number, columns?: number, rows?: number, frameRate?: number, autostart?: boolean): typeof Sprite;
+        makeSprite(pathOrTexture: any, x: number, y: number, columns?: number, rows?: number, frameRate?: number, autostart?: boolean): Sprite;
         /**
          * @name Two#makeImageSequence
          * @function
-         * @param {(String[]|Two.Texture[])} pathsOrTextures - An array of paths or of {@link Two.Textures}.
+         * @param {(String[]|Texture[])} pathsOrTextures - An array of paths or of {@link Two.Textures}.
          * @param {Number} x
          * @param {Number} y
          * @param {Number} [frameRate=0]
          * @param {Boolean} [autostart=false]
-         * @returns {Two.ImageSequence}
+         * @returns {ImageSequence}
          * @description Creates a Two.js image sequence object and adds it to the scene.
          */
-        makeImageSequence(pathsOrTextures: (string[] | (typeof Texture)[]), x: number, y: number, frameRate?: number, autostart?: boolean): typeof ImageSequence;
+        makeImageSequence(pathsOrTextures: any, x: number, y: number, frameRate?: number, autostart?: boolean): ImageSequence;
         /**
          * @name Two#makeTexture
          * @function
          * @param {(String|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement)} [pathOrSource] - The URL path to an image or a DOM image-like element.
          * @param {Function} [callback] - Function to be invoked when the image is loaded.
-         * @returns {Two.Texture}
+         * @returns {Texture}
          * @description Creates a Two.js texture object.
          */
-        makeTexture(pathOrSource?: (string | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement), callback?: Function): typeof Texture;
+        makeTexture(pathOrSource: any, callback?: Function): Texture;
         /**
          * @name Two#makeGroup
          * @function
-         * @param {(Two.Shape[]|...Two.Shape)} [objects] - Two.js objects to be added to the group in the form of an array or as individual arguments.
-         * @returns {Two.Group}
+         * @param {TwoElement[]} [objects] - Two.js objects to be added to the group in the form of an array or as individual arguments.
+         * @returns {Group}
          * @description Creates a Two.js group object and adds it to the scene.
          */
-        makeGroup(objects: any, ...args: any[]): typeof Group;
+        makeGroup(objects?: TwoElement[]): Group;
+        /**
+         * @name Two#makeGroup
+         * @function
+         * @param {...TwoElement} [args] - Alternatively pass each element as an argument
+         * @returns {Group}
+         * @description Creates a Two.js group object and adds it to the scene.
+         */
+        makeGroup(...args: TwoElement[]): Group;
         /**
          * @name Two#interpret
          * @function
          * @param {SVGElement} svg - The SVG node to be parsed.
          * @param {Boolean} shallow - Don't create a top-most group but append all content directly.
          * @param {Boolean} [add=true] – Automatically add the reconstructed SVG node to scene.
-         * @returns {Two.Group}
+         * @returns {Group}
          * @description Interpret an SVG Node and add it to this instance's scene. The distinction should be made that this doesn't `import` svg's, it solely interprets them into something compatible for Two.js - this is slightly different than a direct transcription.
          */
-        interpret(svg: SVGElement, shallow: boolean, add?: boolean): typeof Group;
+        interpret(svg: SVGElement, shallow?: boolean, add?: boolean): Group;
         /**
          * @name Two#load
          * @function
          * @param {String|SVGElement} pathOrSVGContent - The URL path of an SVG file or an SVG document as text.
          * @param {Function} callback - Function to call once loading has completed.
-         * @returns {Two.Group}
+         * @returns {Group}
          * @description Load an SVG file or SVG text and interpret it into Two.js legible objects.
          */
-        load(pathOrSVGContent: string | SVGElement, callback: Function): typeof Group;
+        load(pathOrSVGContent: any, callback: Function): Group;
     }
-    import { Line } from "src/shapes/line";
-    import { Path } from "src/path";
-    import { Rectangle } from "src/shapes/rectangle";
-    import { Circle } from "src/shapes/circle";
-    import { Ellipse } from "src/shapes/ellipse";
-    import { Star } from "src/shapes/star";
-    import { Anchor } from "src/anchor";
-    import { Polygon } from "src/shapes/polygon";
-    import { ArcSegment } from "src/shapes/arc-segment";
-    import { Points } from "src/shapes/points";
-    import { Text } from "src/text";
-    import { LinearGradient } from "src/effects/linear-gradient";
-    import { RadialGradient } from "src/effects/radial-gradient";
-    import { Texture } from "src/effects/texture";
-    import { Sprite } from "src/effects/sprite";
-    import { ImageSequence } from "src/effects/image-sequence";
-    import { Group } from "src/group";
-    import { Collection } from "src/collection";
-    import { Events } from "src/events";
-    import { Matrix } from "src/matrix";
-    import { Registry } from "src/registry";
-    import { Shape } from "src/shape";
-    import { Vector } from "src/vector";
-    import { Gradient } from "src/effects/gradient";
-    import { Stop } from "src/effects/stop";
-    import { RoundedRectangle } from "src/shapes/rounded-rectangle";
-    import { Renderer as CanvasRenderer } from "src/renderers/canvas";
-    import { Renderer as SVGRenderer } from "src/renderers/svg";
-    import { Renderer as WebGLRenderer } from "src/renderers/webgl";
+    import { Line } from "two.js/src/shapes/line";
+    import { Path } from "two.js/src/path";
+    import { Rectangle } from "two.js/src/shapes/rectangle";
+    import { Circle } from "two.js/src/shapes/circle";
+    import { Ellipse } from "two.js/src/shapes/ellipse";
+    import { Star } from "two.js/src/shapes/star";
+    import { Polygon } from "two.js/src/shapes/polygon";
+    import { ArcSegment } from "two.js/src/shapes/arc-segment";
+    import { Points } from "two.js/src/shapes/points";
+    import { Text } from "two.js/src/text";
+    import { LinearGradient } from "two.js/src/effects/linear-gradient";
+    import { RadialGradient } from "two.js/src/effects/radial-gradient";
+    import { Sprite } from "two.js/src/effects/sprite";
+    import { ImageSequence } from "two.js/src/effects/image-sequence";
+    import { Texture } from "two.js/src/effects/texture";
+    import { Group } from "two.js/src/group";
+    import { Anchor } from "two.js/src/anchor";
+    import { Collection } from "two.js/src/collection";
+    import { Events } from "two.js/src/events";
+    import { Matrix } from "two.js/src/matrix";
+    import { Registry } from "two.js/src/registry";
+    import { Shape } from "two.js/src/shape";
+    import { Vector } from "two.js/src/vector";
+    import { Gradient } from "two.js/src/effects/gradient";
+    import { Stop } from "two.js/src/effects/stop";
+    import { RoundedRectangle } from "two.js/src/shapes/rounded-rectangle";
+    import { Renderer as CanvasRenderer } from "two.js/src/renderers/canvas";
+    import { Renderer as SVGRenderer } from "two.js/src/renderers/svg";
+    import { Renderer as WebGLRenderer } from "two.js/src/renderers/webgl";
+    import { Element as TwoElement } from 'two.js/src/element'
 }
-declare module "extras/jsm/arc" {
-    /**
-     * @name Two.Arc
-     * @class
-     * @extends Two.Path
-     * @param {Number} [x=0] - The x position of the arc.
-     * @param {Number} [y=0] - The y position of the arc.
-     * @param {Number} [width=0] - The width, horizontal diameter, of the arc.
-     * @param {Number} [height=0] - The height, vertical diameter, of the arc.
-     * @param {Number} [startAngle=0] - The starting angle of the arc in radians.
-     * @param {Number} [endAngle=6.283] - The ending angle of the arc in radians.
-     * @param {Number} [resolution=4] - The number of vertices used to construct the circle.
-     */
-    export class Arc {
-        /**
-         * @name Two.Arc.Properties
-         * @property {String[]} - A list of properties that are on every {@link Two.Arc}.
-         */
-        static Properties: string[];
-        constructor(x: any, y: any, width: any, height: any, startAngle: any, endAngle: any, resolution: any);
-        _flagWidth: boolean;
-        _flagHeight: boolean;
-        _flagStartAngle: boolean;
-        _flagEndAngle: boolean;
-        _width: number;
-        _height: number;
-        _startAngle: number;
-        _endAngle: number;
-        curved: boolean;
-        width: number;
-        height: number;
-        startAngle: number;
-        endAngle: number;
-        /**
-         * @name Two.Arc#_update
-         * @function
-         * @private
-         * @param {Boolean} [bubbles=false] - Force the parent to `_update` as well.
-         * @description This is called before rendering happens by the renderer. This applies all changes necessary so that rendering is up-to-date but not updated more than it needs to be.
-         * @nota-bene Try not to call this method more than once a frame.
-         */
-        private _update;
-        /**
-         * @name Two.Arc#flagReset
-         * @function
-         * @private
-         * @description Called internally to reset all flags. Ensures that only properties that change are updated before being sent to the renderer.
-         */
-        private flagReset;
-        /**
-         * @name Two.Arc#clone
-         * @function
-         * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-         * @returns {Two.ArcSegment}
-         * @description Create a new instance of {@link Two.ArcSegment} with the same properties of the current path.
-         */
-        clone(): Two.ArcSegment;
-    }
-}
-declare module "extras/jsm/zui" {
+declare module "two.js/extras/jsm/zui" {
     /**
      * @name Two.ZUI
      * @class
-     * @param {Two.Group} group - The scene or group to
+     * @param {Group} group - The scene or group to
      * @param {HTMLElement} [domElement=document.body] - The HTML Element to attach event listeners to.
-     * @description {@link Two.ZUI} is an extra class to turn your Two.js scene into a Google Maps or Adobe Illustrator style interface. See {@link https://codepen.io/jonobr1/pen/PobMKwb} for example usage.
      */
     export class ZUI {
-        static Surface: typeof Surface;
+        static Surface: Surface;
         static Clamp(v: any, min: any, max: any): number;
         static Limit: {
             min: number;
@@ -5017,7 +4470,7 @@ declare module "extras/jsm/zui" {
         static TranslateMatrix(m: any, x: any, y: any): any;
         static PositionToScale(pos: any): number;
         static ScaleToPosition(scale: any): number;
-        constructor(group: any, domElement: any);
+        constructor(group?: Group, domElement?: HTMLElement);
         limits: {
             scale: {};
             x: {};
@@ -5032,88 +4485,21 @@ declare module "extras/jsm/zui" {
         surfaceMatrix: Matrix;
         surfaces: any[];
         add(surface: any): ZUI;
-        /**
-         * @name Two.ZUI#addLimits
-         * @function
-         * @param {Number} [min=-Infinity] - The minimum scale the ZUI can zoom out to.
-         * @param {Number} [max=Infinity] - The maximum scale teh ZUI can zoom in to.
-         */
-        addLimits(min?: number, max?: number): ZUI;
-        /**
-         * @name Two.ZUI#clientToSurface
-         * @function
-         * @param {Two.Vector} a
-         * @description Convert an x, y coordinate in the user’s space to the object's projected space. Optionally pass a z property on the object to apply depth.
-         * @returns {Object} - An object with x, y, and z components
-         * @overloaded
-         */
-        /**
-         * @name Two.ZUI#clientToSurface
-         * @param {Number} [a=0] - The x component of position to be transformed.
-         * @param {Number} [b=0] - The y component of position to be transformed.
-         * @param {Number} [c=1] - The optional z component of position to be transformed.
-         * @description Convert an x, y coordinate in the user’s space to the object's projected space. Optionally pass a z property on the object to apply depth.
-         * @returns {Object} - An object with x, y, and z components
-         * @overloaded
-         */
-        clientToSurface(a?: number, b?: number, c?: number, ...args: any[]): any;
-        /**
-         * @name Two.ZUI#surfaceToClient
-         * @function
-         * @param {Two.Vector} a
-         * @description Convert an x, y coordinate in projected space to the user’s space. Optionally pass a z property on the object to apply depth.
-         * @returns {Object} - An object with x, y, and z components
-         * @overloaded
-         */
-        /**
-         * @name Two.ZUI#surfaceToClient
-         * @param {Number} [a=0] - The x component of position to be transformed.
-         * @param {Number} [b=0] - The y component of position to be transformed.
-         * @param {Number} [c=1] - The optional z component of position to be transformed.
-         * @description Convert an x, y coordinate in projected space to the user’s space. Optionally pass a z property on the object to apply depth.
-         * @returns {Object} - An object with x, y, and z components
-         * @overloaded
-         */
-        surfaceToClient(a?: number, b?: number, c?: number, ...args: any[]): any;
-        /**
-         * @name Two.ZUI#zoomBy
-         * @function
-         * @param {Number} byF - The factor to scale by.
-         * @param {Number} clientX - The x position of the user's input.
-         * @param {Number} clientY - The y position of the user's input.
-         * @description A function to zoom by an incremental amount and a position. Typically used for pinch-and-zoom or mousewheel effects.
-         */
-        zoomBy(byF: number, clientX: number, clientY: number): ZUI;
-        /**
-         * @name Two.ZUI#zoomSet
-         * @function
-         * @param {Number} zoom - The level of the zoom.
-         * @param {Number} clientX - The x position of the user's input.
-         * @param {Number} clientY - The y position of the user's input.
-         * @description A function to set the zoom amount and the origin position. This is used internally by {@Two.ZUI#zoomBy}.
-         */
-        zoomSet(zoom: number, clientX: number, clientY: number): ZUI;
+        addLimits(min: number, max: number, type?: number): ZUI;
+        clientToSurface(v?: { x?: number, y?: number, z?: number }): { x: number, y: number, z: number };
+        surfaceToClient(v?: { x?: number, y?: number, z?: number }): { x: number, y: number, z: number };
+        zoomBy(byF: any, clientX: any, clientY: any): ZUI;
+        zoomSet(zoom: any, clientX: any, clientY: any): ZUI;
         zoom: number;
         scale: any;
-        /**
-         * @name Two.ZUI#translateSurface
-         * @function
-         * @param {Number} x - The x amount to pan.
-         * @param {Number} y - The y amount to pan.
-         * @description Set the position of the ZUI by an incremental translation amount.
-         */
-        translateSurface(x: number, y: number): ZUI;
+        translateSurface(x: any, y: any): ZUI;
         updateOffset(): ZUI;
         updateSurface(): ZUI;
-        /**
-         * @name Two.ZUI#reset
-         * @function
-         * @description Reset the zoom and scale factors to their original instantiated state.
-         */
         reset(): ZUI;
         fitToLimits(s: any): number;
     }
-    import { Matrix } from "src/matrix";
+    import { Matrix } from "two.js/src/matrix";
+    import { Group } from "two.js/src/group";
     class Surface {
         constructor(object: any);
         object: any;
@@ -5125,5 +4511,4 @@ declare module "extras/jsm/zui" {
         max: any;
         apply(px: any, py: any, s: any): Surface;
     }
-    export {};
 }


### PR DESCRIPTION
I spotted some minor errors/typos in the docs for `makeLinearGradient` and `makeRadialGradient`. Here's a quick patch to fix.

Thanks for the project! I've really enjoyed using it.