### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/effects/texture.js
+++ b/src/effects/texture.js
@@ -261,7 +261,7 @@ export class Texture extends Element {
 
   /**
    * @name Two.Texture.getImage
-   * @property {Function} - Convenience function to set {@link Two.Texture#image} properties with canonincal versions set in {@link Two.Texture.ImageRegistry}.
+   * @property {Function} - Convenience function to set {@link Two.Texture#image} properties with canonical versions set in {@link Two.Texture.ImageRegistry}.
    * @param {String} src - The URL path of the image.
    * @returns {HTMLImageElement} - Returns either a cached version of the image or a new one that is registered in {@link Two.Texture.ImageRegistry}.
    */

--- a/src/events.js
+++ b/src/events.js
@@ -48,7 +48,7 @@ export class Events {
    * @name Two.Events#removeEventListener
    * @function
    * @param {String} [name] - The name of the event intended to be removed.
-   * @param {Function} [handler] - The handler intended to be reomved.
+   * @param {Function} [handler] - The handler intended to be removed.
    * @description Call to remove listeners from a specific event. If only `name` is passed then all the handlers attached to that `name` will be removed. If no arguments are passed then all handlers for every event on the obejct are removed.
    */
   removeEventListener(name, handler) {

--- a/src/path.js
+++ b/src/path.js
@@ -1367,7 +1367,7 @@ const proto = {
   /**
    * @name Two.Path#mask
    * @property {Two.Shape} - The shape whose alpha property becomes a clipping area for the path.
-   * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
+   * @nota-bene This property is currently not working because of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
    */
   mask: {
 

--- a/src/shapes/points.js
+++ b/src/shapes/points.js
@@ -70,7 +70,7 @@ export class Points extends Shape {
 
     /**
      * @name Two.Points#sizeAttenuation
-     * @property {Boolean} - Boolean dictating whether Two.js should scale the size of the points based on its matrix hierarcy.
+     * @property {Boolean} - Boolean dictating whether Two.js should scale the size of the points based on its matrix hierarchy.
      * @description Set to `true` if you'd like the size of the points to be relative to the scale of its parents; `false` to disregard. Default is `false`.
      */
     this.sizeAttenuation = false;

--- a/src/text.js
+++ b/src/text.js
@@ -152,7 +152,7 @@ export class Text extends Shape {
 
   /**
    * @name Two.Text#family
-   * @property {String} - The font family Two.js should attempt to regsiter for rendering. The default value is `'sans-serif'`. Comma separated font names can be supplied as a "stack", similar to the CSS implementation of `font-family`.
+   * @property {String} - The font family Two.js should attempt to register for rendering. The default value is `'sans-serif'`. Comma separated font names can be supplied as a "stack", similar to the CSS implementation of `font-family`.
    */
   _family = 'sans-serif';
 
@@ -236,14 +236,14 @@ export class Text extends Shape {
   /**
    * @name Two.Text#mask
    * @property {Two.Shape} - The shape whose alpha property becomes a clipping area for the text.
-   * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
+   * @nota-bene This property is currently not working because of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
    */
   _mask = null;
 
   /**
    * @name Two.Text#clip
    * @property {Two.Shape} - Object to define clipping area.
-   * @nota-bene This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
+   * @nota-bene This property is currently not working because of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
    */
   _clip = false;
 

--- a/wiki/changelog/README.md
+++ b/wiki/changelog/README.md
@@ -406,7 +406,7 @@ All notable changes to this project will be documented in this file. The format 
 + Modified source to not have any instances of `window` for node use
 + Updated to underscore.js 1.5.1
 + Added `Two.Utils.getReflection` method to properly get reflection's in svg interpretation
-+ Made `Two.Vector` inherently not broadcast events and now needs to be explicity bound to in order to broadcast events, which two.js does internally for you
++ Made `Two.Vector` inherently not broadcast events and now needs to be explicitly bound to in order to broadcast events, which two.js does internally for you
 + Created `Two.Utils.Collection` an observable array-like class that `polygon.vertices` inherit [@fchasen](http://github.com/fchasen)
 + Added `Two.Events.insert` and `Two.Events.remove` for use with `Two.Utils.Collection`
 + Properly recurses `getBoundingClientRect` for both `Two.Group` and `Two.Polygon`

--- a/wiki/docs/events/README.md
+++ b/wiki/docs/events/README.md
@@ -235,7 +235,7 @@ Alias for [Two.Events.addEventListener](/docs/events/#addeventlistener).
 | Argument | Description |
 | ---- | ----------- |
 |  name  | The name of the event intended to be removed. |
-|  handler  | The handler intended to be reomved. |
+|  handler  | The handler intended to be removed. |
 </div>
 
 

--- a/wiki/docs/path/README.md
+++ b/wiki/docs/path/README.md
@@ -1619,7 +1619,7 @@ The shape whose alpha property becomes a clipping area for the path.
 
 
 ::: tip nota-bene
-This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
+This property is currently not working because of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
 :::
 
 

--- a/wiki/docs/shapes/points/README.md
+++ b/wiki/docs/shapes/points/README.md
@@ -52,7 +52,7 @@ This is a primary primitive class for quickly and easily drawing points in Two.j
 <div class="properties">
 
 
-Boolean dictating whether Two.js should scale the size of the points based on its matrix hierarcy.
+Boolean dictating whether Two.js should scale the size of the points based on its matrix hierarchy.
 
 
 </div>

--- a/wiki/docs/text/README.md
+++ b/wiki/docs/text/README.md
@@ -252,7 +252,7 @@ The characters to be rendered to the the screen. Referred to in the documentatio
 <div class="properties">
 
 
-The font family Two.js should attempt to regsiter for rendering. The default value is `'sans-serif'`. Comma separated font names can be supplied as a "stack", similar to the CSS implementation of `font-family`.
+The font family Two.js should attempt to register for rendering. The default value is `'sans-serif'`. Comma separated font names can be supplied as a "stack", similar to the CSS implementation of `font-family`.
 
 
 </div>
@@ -933,7 +933,7 @@ The shape whose alpha property becomes a clipping area for the text.
 
 
 ::: tip nota-bene
-This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
+This property is currently not working because of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
 :::
 
 
@@ -990,7 +990,7 @@ Object to define clipping area.
 
 
 ::: tip nota-bene
-This property is currently not working becuase of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
+This property is currently not working because of SVG spec issues found here {@link https://code.google.com/p/chromium/issues/detail?id=370951}.
 :::
 
 


### PR DESCRIPTION
There are small typos in:
- src/effects/texture.js
- src/events.js
- src/path.js
- src/shapes/points.js
- src/text.js
- wiki/changelog/README.md
- wiki/docs/events/README.md
- wiki/docs/path/README.md
- wiki/docs/shapes/points/README.md
- wiki/docs/text/README.md

Fixes:
- Should read `because` rather than `becuase`.
- Should read `removed` rather than `reomved`.
- Should read `register` rather than `regsiter`.
- Should read `hierarchy` rather than `hierarcy`.
- Should read `explicitly` rather than `explicity`.
- Should read `canonical` rather than `canonincal`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md