### PR TITLE
Fix documentation typo in ZUI package

### DIFF
--- a/extras/jsm/zui.js
+++ b/extras/jsm/zui.js
@@ -102,7 +102,7 @@ export class ZUI {
    * @name Two.ZUI#addLimits
    * @function
    * @param {Number} [min=-Infinity] - The minimum scale the ZUI can zoom out to.
-   * @param {Number} [max=Infinity] - The maximum scale teh ZUI can zoom in to.
+   * @param {Number} [max=Infinity] - The maximum scale the ZUI can zoom in to.
    */
   addLimits(min, max) {
     if (typeof min !== 'undefined') {

--- a/wiki/docs/extras/zui/README.md
+++ b/wiki/docs/extras/zui/README.md
@@ -51,7 +51,7 @@ lang: en-US
 | Argument | Description |
 | ---- | ----------- |
 |  min  | The minimum scale the ZUI can zoom out to. |
-|  max  | The maximum scale teh ZUI can zoom in to. |
+|  max  | The maximum scale the ZUI can zoom in to. |
 </div>
 
 


### PR DESCRIPTION
This PR fixes a tiny typo in one of the zui jsdoc param descriptions