### PR TITLE
imports: Use relative imports consistently

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -1,5 +1,5 @@
 import { Events } from './events.js';
-import { Constants } from 'constants.js';
+import { Constants } from './constants.js';
 
 /**
  * @name Two.Element

--- a/src/group.js
+++ b/src/group.js
@@ -1,20 +1,20 @@
 import { Events } from './events.js';
 import { _ } from './utils/underscore.js';
-import { getEffectFromObject } from 'utils/shape.js';
+import { getEffectFromObject } from './utils/shape.js';
 
 import { Shape } from './shape.js';
 import { Children } from './children.js';
-import { Path } from 'path.js';
-import { ArcSegment } from 'shapes/arc-segment.js';
-import { Circle } from 'shapes/circle.js';
-import { Ellipse } from 'shapes/ellipse.js';
-import { Points } from 'shapes/points.js';
-import { Polygon } from 'shapes/polygon.js';
-import { Rectangle } from 'shapes/rectangle.js';
-import { RoundedRectangle } from 'shapes/rounded-rectangle.js';
-import { Star } from 'shapes/star.js';
-import { Text } from 'text.js';
-import { Element } from 'element.js';
+import { Path } from './path.js';
+import { ArcSegment } from './shapes/arc-segment.js';
+import { Circle } from './shapes/circle.js';
+import { Ellipse } from './shapes/ellipse.js';
+import { Points } from './shapes/points.js';
+import { Polygon } from './shapes/polygon.js';
+import { Rectangle } from './shapes/rectangle.js';
+import { RoundedRectangle } from './shapes/rounded-rectangle.js';
+import { Star } from './shapes/star.js';
+import { Text } from './text.js';
+import { Element } from './element.js';
 
 // Constants
 

--- a/src/text.js
+++ b/src/text.js
@@ -8,7 +8,7 @@ import { LinearGradient } from './effects/linear-gradient.js';
 import { RadialGradient } from './effects/radial-gradient.js';
 import { Texture } from './effects/texture.js';
 import { root } from './utils/root.js';
-import { getEffectFromObject } from 'utils/shape.js';
+import { getEffectFromObject } from './utils/shape.js';
 
 let canvas;
 const min = Math.min,

--- a/src/utils/shape.js
+++ b/src/utils/shape.js
@@ -1,8 +1,8 @@
-import { Texture } from 'effects/texture.js';
+import { Texture } from '../effects/texture.js';
 import { subdivide, getCurveLength as gcl } from './curves.js';
-import { Gradient } from 'effects/gradient.js';
-import { LinearGradient } from 'effects/linear-gradient.js';
-import { RadialGradient } from 'effects/radial-gradient.js';
+import { Gradient } from '../effects/gradient.js';
+import { LinearGradient } from '../effects/linear-gradient.js';
+import { RadialGradient } from '../effects/radial-gradient.js';
 
 /**
  * @private


### PR DESCRIPTION
There is a mix of relative and non-relative imports. Webpack has an issue with non-relative imports unless the preferRelative resolve configuration is set true. This works for most of the non-relative imports except where ".." is used. Instead, a better solution is to use relative imports for all imports.