### PR TITLE
Two.Group.getById() optimization

### DIFF
--- a/src/group.js
+++ b/src/group.js
@@ -482,6 +482,9 @@ export class Group extends Shape {
       if (node.id === id) {
         return node;
       } else if (node.children) {
+        if (node.children.ids[id]) {
+          return node.children.ids[id];
+        }
         for (let i = 0; i < node.children.length; i++) {
           found = search(node.children[i]);
           if (found) {


### PR DESCRIPTION
The name of Two.Group.getById() somewhat implies it would use the Two.Group.children.ids map but actually just loops through every child until found, which can decrease performance if you need to grab many objects from a large group by id and are unaware.

The optimization checks if the object is present in the ids map before looping through all children, and returns the item if found. It still reverts to the old way of checking if the object isn't found in the ids map, so nested objects and objects not in the id map will still be found.

Validated the speed increase with the test cases here: https://github.com/Aries1542/two.js-speed-test.
For those cases, Two.Group.getById() went from around 30x as slow to about equal to Two.Group.children.ids[] for random cases and 60x as slow to about equal in the worst case.

I wasn't able to get your tests running on my machine however so that should probably still be checked.

