### PR TITLE
Fix dashes type definition

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -376,7 +376,7 @@ export class Path extends Shape {
     /**
      * @name Two.Path#dashes
      * @type {number[] & { offset?: number }}
-     * @property {number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
+     * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */

--- a/src/path.js
+++ b/src/path.js
@@ -375,7 +375,8 @@ export class Path extends Shape {
 
     /**
      * @name Two.Path#dashes
-     * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
+     * @type {number[] & { offset: number }}
+     * @property {number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */

--- a/src/path.js
+++ b/src/path.js
@@ -375,7 +375,7 @@ export class Path extends Shape {
 
     /**
      * @name Two.Path#dashes
-     * @type {number[] & { offset: number }}
+     * @type {number[] & { offset?: number }}
      * @property {number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.

--- a/src/shapes/points.js
+++ b/src/shapes/points.js
@@ -61,7 +61,7 @@ export class Points extends Shape {
       Object.defineProperty(this, prop, proto[prop]);
     }
 
-    this._renderer.type = 'points';
+    this._renderer.type = "points";
     this._renderer.flagVertices = FlagVertices.bind(this);
     this._renderer.bindVertices = BindVertices.bind(this);
     this._renderer.unbindVertices = UnbindVertices.bind(this);
@@ -106,14 +106,14 @@ export class Points extends Shape {
      * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be filled in with.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
      */
-    this.fill = '#fff';
+    this.fill = "#fff";
 
     /**
      * @name Two.Points#stroke
      * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be outlined in with.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
      */
-    this.stroke = '#000';
+    this.stroke = "#000";
 
     /**
      * @name Two.Points#linewidth
@@ -133,7 +133,7 @@ export class Points extends Shape {
      * @property {String} - A class to be applied to the element to be compatible with CSS styling.
      * @nota-bene Only available for the SVG renderer.
      */
-    this.className = '';
+    this.className = "";
 
     /**
      * @name Two.Points#visible
@@ -152,6 +152,7 @@ export class Points extends Shape {
 
     /**
      * @name Two.Points#dashes
+     * @type {number[] & { offset: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.

--- a/src/shapes/points.js
+++ b/src/shapes/points.js
@@ -61,7 +61,7 @@ export class Points extends Shape {
       Object.defineProperty(this, prop, proto[prop]);
     }
 
-    this._renderer.type = "points";
+    this._renderer.type = 'points';
     this._renderer.flagVertices = FlagVertices.bind(this);
     this._renderer.bindVertices = BindVertices.bind(this);
     this._renderer.unbindVertices = UnbindVertices.bind(this);
@@ -106,14 +106,14 @@ export class Points extends Shape {
      * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be filled in with.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
      */
-    this.fill = "#fff";
+    this.fill = '#fff';
 
     /**
      * @name Two.Points#stroke
      * @property {(String|Two.Gradient|Two.Texture)} - The value of what the path should be outlined in with.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color_value} for more information on CSS's colors as `String`.
      */
-    this.stroke = "#000";
+    this.stroke = '#000';
 
     /**
      * @name Two.Points#linewidth
@@ -133,7 +133,7 @@ export class Points extends Shape {
      * @property {String} - A class to be applied to the element to be compatible with CSS styling.
      * @nota-bene Only available for the SVG renderer.
      */
-    this.className = "";
+    this.className = '';
 
     /**
      * @name Two.Points#visible
@@ -152,7 +152,7 @@ export class Points extends Shape {
 
     /**
      * @name Two.Points#dashes
-     * @type {number[] & { offset: number }}
+     * @type {number[] & { offset?: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.

--- a/src/text.js
+++ b/src/text.js
@@ -274,21 +274,22 @@ export class Text extends Shape {
       Object.defineProperty(this, prop, proto[prop]);
     }
 
-    this._renderer.type = 'text';
+    this._renderer.type = "text";
     this._renderer.flagFill = FlagFill.bind(this);
     this._renderer.flagStroke = FlagStroke.bind(this);
 
     this.value = message;
 
-    if (typeof x === 'number') {
+    if (typeof x === "number") {
       this.translation.x = x;
     }
-    if (typeof y === 'number') {
+    if (typeof y === "number") {
       this.translation.y = y;
     }
 
     /**
      * @name Two.Text#dashes
+     * @type {number[] & { offset: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.

--- a/src/text.js
+++ b/src/text.js
@@ -274,22 +274,22 @@ export class Text extends Shape {
       Object.defineProperty(this, prop, proto[prop]);
     }
 
-    this._renderer.type = "text";
+    this._renderer.type = 'text';
     this._renderer.flagFill = FlagFill.bind(this);
     this._renderer.flagStroke = FlagStroke.bind(this);
 
     this.value = message;
 
-    if (typeof x === "number") {
+    if (typeof x === 'number') {
       this.translation.x = x;
     }
-    if (typeof y === "number") {
+    if (typeof y === 'number') {
       this.translation.y = y;
     }
 
     /**
      * @name Two.Text#dashes
-     * @type {number[] & { offset: number }}
+     * @type {number[] & { offset?: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.

--- a/types.d.ts
+++ b/types.d.ts
@@ -2888,11 +2888,14 @@ declare module 'two.js/src/path' {
     automatic: boolean;
     /**
      * @name Two.Path#dashes
+     * @type {number[] & { offset: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */
-    dashes: { [key: number]: number; offset: number };
+    dashes: number[] & {
+      offset: number;
+    };
     /**
      * @name Two.Path#copy
      * @function
@@ -3677,11 +3680,14 @@ declare module 'two.js/src/text' {
     clip: boolean;
     /**
      * @name Two.Text#dashes
+     * @type {number[] & { offset: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */
-    dashes: { [key: number]: number; offset: number };
+    dashes: number[] & {
+      offset: number;
+    };
     /**
      * @name Two.Text#toObject
      * @function
@@ -4078,11 +4084,14 @@ declare module 'two.js/src/shapes/points' {
     vertices: (Anchor | Vector)[];
     /**
      * @name Two.Points#dashes
+     * @type {number[] & { offset: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */
-    dashes: { [key: number]: number; offset: number };
+    dashes: number[] & {
+      offset: number;
+    };
     /**
      * @name Two.Points#toObject
      * @function

--- a/types.d.ts
+++ b/types.d.ts
@@ -2888,13 +2888,13 @@ declare module 'two.js/src/path' {
     automatic: boolean;
     /**
      * @name Two.Path#dashes
-     * @type {number[] & { offset: number }}
+     * @type {number[] & { offset?: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */
     dashes: number[] & {
-      offset: number;
+      offset?: number;
     };
     /**
      * @name Two.Path#copy
@@ -3680,13 +3680,13 @@ declare module 'two.js/src/text' {
     clip: boolean;
     /**
      * @name Two.Text#dashes
-     * @type {number[] & { offset: number }}
+     * @type {number[] & { offset?: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */
     dashes: number[] & {
-      offset: number;
+      offset?: number;
     };
     /**
      * @name Two.Text#toObject
@@ -4084,13 +4084,13 @@ declare module 'two.js/src/shapes/points' {
     vertices: (Anchor | Vector)[];
     /**
      * @name Two.Points#dashes
-     * @type {number[] & { offset: number }}
+     * @type {number[] & { offset?: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
      * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */
     dashes: number[] & {
-      offset: number;
+      offset?: number;
     };
     /**
      * @name Two.Points#toObject


### PR DESCRIPTION
The dashes property of the path, text and points types is described as an object with index access and an additional offset property. However, two.js assumes an array with an additional offset property. Therefore, the provided data results in a runtime error.

The expected data, according to the TypeScript type definition, is as follows:
```typescript
l.dashes = { 0: 5, 1: 5, offset: 0 };
```

Correct data:
```typescript
l.dashes = [5, 5];
l.dashes.offset = 0;
```