### PR TITLE
Potential fix for code scanning alert no. 6: Useless conditional

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -1056,12 +1056,6 @@ export class Path extends Shape {
         this._lengths[i] = getCurveLength(a, b, limit);
         sum += this._lengths[i];
 
-        if (i >= last && closed) {
-          b = this.vertices[(i + 1) % length];
-
-          this._lengths[i + 1] = getCurveLength(a, b, limit);
-          sum += this._lengths[i + 1];
-        }
 
         b = a;
       },


### PR DESCRIPTION
Potential fix for [https://github.com/jonobr1/two.js/security/code-scanning/6](https://github.com/jonobr1/two.js/security/code-scanning/6)

To fix this error, the useless conditional should be removed. Specifically, the block of code inside the `if (i >= last && closed)` statement (lines 1059–1064) should be eliminated because it will never execute in its current form. Ideally, we should remove both the wrapper `if` statement and the enclosed code within this method. No changes are necessary elsewhere in this file for functionality. If, in the future, `closed` is controlled by logic, this code may need to be reintroduced, but as things stand, it is safe to remove. No imports or additional definitions are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
