### PR TITLE
Potential fix for code scanning alert no. 54: Useless assignment to local variable

### DIFF
--- a/tests/typescript/index.ts
+++ b/tests/typescript/index.ts
@@ -7,15 +7,6 @@ const two = new Two({
 
 let path;
 
-path = Two.Circle.fromObject({
-  radius: 5,
-  stroke: 'blue',
-  fill: 'yellow',
-  // position: new Two.Vector(),
-  rotation: 5,
-  translation: { x: 0, y: 0 },
-});
-
 path = new Two.Line(5, 5, 10, 10);
 two.add(path);
 


### PR DESCRIPTION
Potential fix for [https://github.com/jonobr1/two.js/security/code-scanning/54](https://github.com/jonobr1/two.js/security/code-scanning/54)

In general, a "useless assignment to local variable" is fixed either by removing the dead assignment entirely or by actually using the value that was intended to be used. Here, the `path` value from `Two.Circle.fromObject(...)` is never used before being overwritten by `new Two.Line(...)`, and nothing in the following code depends on that circle. The minimal fix without changing behavior is to remove this unused assignment (and its object literal), leaving the rest of the logic intact.

Concretely, in `tests/typescript/index.ts`, delete the block that assigns `path = Two.Circle.fromObject({ ... })` on lines 10–17. No additional imports, helper methods, or definitions are needed, and no other lines must be changed, because the subsequent uses of `path` (starting from the line assignment) remain the same and still function correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
