### PR TITLE
Potential fix for code scanning alert no. 56: Unused variable, import, function or class

### DIFF
--- a/tests/suite/dispose.js
+++ b/tests/suite/dispose.js
@@ -1142,7 +1142,6 @@
   QUnit.test('Texture.dispose - Event Unbinding', function (assert) {
     assert.expect(3);
 
-    // eslint-disable-next-line no-unused-vars
     new Two({
       type: Two.Types.svg,
       width: 400,

--- a/tests/suite/dispose.js
+++ b/tests/suite/dispose.js
@@ -1143,7 +1143,7 @@
     assert.expect(3);
 
     // eslint-disable-next-line no-unused-vars
-    var two = new Two({
+    new Two({
       type: Two.Types.svg,
       width: 400,
       height: 400,


### PR DESCRIPTION
Potential fix for [https://github.com/jonobr1/two.js/security/code-scanning/56](https://github.com/jonobr1/two.js/security/code-scanning/56)

In general, unused variables should either be removed entirely or, if their initialization side effects are required, the initialization should be kept without binding the result to a name. Here, we want to avoid changing behavior: the construction of `new Two({...}).appendTo(document.body);` should still run, but the unused binding `var two =` should be removed so there is no unused variable.

The best fix is therefore to replace `var two = new Two({ ... }).appendTo(document.body);` with a bare expression `new Two({ ... }).appendTo(document.body);` in the `Texture.dispose - Event Unbinding` test. This keeps the renderer/DOM setup side effects but eliminates the unused `two` variable. No new imports, methods, or definitions are required. Concretely, in `tests/suite/dispose.js`, around line 1145–1150, update that single declaration line to remove `var two =`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
