### PR TITLE
Potential fix for code scanning alert no. 55: Unused variable, import, function or class

### DIFF
--- a/tests/suite/dispose.js
+++ b/tests/suite/dispose.js
@@ -1107,13 +1107,6 @@
   QUnit.test('Texture.dispose - Parent Dispose Called', function (assert) {
     assert.expect(3);
 
-    // eslint-disable-next-line no-unused-vars
-    var two = new Two({
-      type: Two.Types.svg,
-      width: 400,
-      height: 400,
-    }).appendTo(document.body);
-
     var texture = new Two.Texture('./images/canvas/line@2x.png');
 
     // Bind event to texture


### PR DESCRIPTION
Potential fix for [https://github.com/jonobr1/two.js/security/code-scanning/55](https://github.com/jonobr1/two.js/security/code-scanning/55)

In general, unused variables should be removed, along with any associated comments that disable linting rules for them. This improves readability and avoids misleading future maintainers into thinking the variable has a purpose.

For this specific case in `tests/suite/dispose.js`, within the `QUnit.test('Texture.dispose - Parent Dispose Called', ...)` block, we should remove the declaration of `two` at lines 1111–1115 as well as the preceding `// eslint-disable-next-line no-unused-vars` comment. The remainder of the test—creating a `Texture`, binding and triggering a `change` event, calling `texture.dispose()`, and verifying that events are unbound and `_bound` is false—remains unchanged. No new imports, methods, or definitions are needed; we are only deleting unused code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
