### PR TITLE
Add Scorecard CI and standardize workflow permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,7 @@
 name: "CodeQL"
 
+permissions: read-all
+
 on:
   push:
     branches: [ "dev" ]
@@ -13,7 +15,6 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: read
       security-events: write
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,5 @@
 name: "CodeQL"
 
-permissions: read-all
-
 on:
   push:
     branches: [ "dev" ]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Lint
+
 on: [push, pull_request]
+
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,14 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  id-token: write  # Required for OIDC
-  contents: read
+permissions: read-all
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: read
     steps:
       # checkout@v6
       - uses: jonobr1/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,6 @@ jobs:
       security-events: write
       id-token: write
       contents: read
-      actions: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '30 1 * * 1'  # Every Monday at 1:30 AM UTC
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
 
 permissions: read-all
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,39 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 1'  # Every Monday at 1:30 AM UTC
+  push:
+    branches: ["main"]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
+        with:
+          sarif_file: results.sarif
+          wait-for-processing: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Two.js
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jonobr1/two.js/badge)](https://scorecard.dev/viewer/?uri=github.com/jonobr1/two.js)
 [![NPM Package][npm]][npm-url]
 [![Build Size][build-size]][build-size-url]
 [![NPM Downloads][npm-downloads]][npmtrends-url]


### PR DESCRIPTION
Add a new GitHub Actions workflow (scorecard.yml) to run OSSF Scorecard on a schedule, on pushes to main, and on branch protection events; it checks out code, runs Scorecard, and uploads SARIF results. Standardize permissions across workflows by setting permissions: read-all at the top-level for codeql.yml, lint.yml, and publish.yml and adjust job-level permissions (e.g., move id-token/write and contents/read into the publish job, remove actions: write from the CodeQL job). Also add an OpenSSF Scorecard badge to the README.