### PR TITLE
Use jonobr1 forks for workflow actions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,19 +20,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: jonobr1/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
         with:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        uses: jonobr1/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
+        uses: jonobr1/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3  # v3.35.1
         with:
           sarif_file: results.sarif
           wait-for-processing: true


### PR DESCRIPTION
Update the workflow to point the 'uses' entries at jonobr1 forked repositories for checkout, ossf/scorecard-action, and codeql-action/upload-sarif. The referenced commit SHAs and action parameters (persist-credentials, results_file/results_format/publish_results, sarif_file/wait-for-processing) are preserved; this changes only the action sources.