### PR TITLE
Fix API docs and shape factory signatures

### DIFF
--- a/extras/js/arc.js
+++ b/extras/js/arc.js
@@ -62,16 +62,16 @@
       }
 
       /**
-       * @name Two.ArcSegment#startAngle
-       * @property {Number} - The angle of one side for the arc segment.
+       * @name Two.Arc#startAngle
+       * @property {Number} - The starting angle of the arc in radians.
        */
       if (typeof startAngle === 'number') {
         this.startAngle = startAngle;
       }
 
       /**
-       * @name Two.ArcSegment#endAngle
-       * @property {Number} - The angle of the other side for the arc segment.
+       * @name Two.Arc#endAngle
+       * @property {Number} - The ending angle of the arc in radians.
        */
       if (typeof endAngle === 'number') {
         this.endAngle = endAngle;
@@ -151,10 +151,10 @@
      * @name Two.Arc#clone
      * @function
      * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-     * @returns {Two.ArcSegment}
-     * @description Create a new instance of {@link Two.ArcSegment} with the same properties of the current path.
+     * @returns {Two.Arc}
+     * @description Create a new instance of {@link Two.Arc} with the same properties as the current arc.
      */
-    clone() {
+    clone(parent) {
       const { width, height, startAngle, endAngle } = this;
       const resolution = this.vertices.length;
 

--- a/extras/js/zui.js
+++ b/extras/js/zui.js
@@ -28,7 +28,7 @@
   /**
    * @name Two.ZUI
    * @class
-   * @param {Two.Group} group - The scene or group to
+   * @param {Two.Group} group - The scene or group to enable panning and zooming on.
    * @param {HTMLElement} [domElement=document.body] - The HTML Element to attach event listeners to.
    */
   class ZUI {

--- a/extras/jsm/arc.js
+++ b/extras/jsm/arc.js
@@ -66,16 +66,16 @@ export class Arc extends Path {
     }
 
     /**
-     * @name Two.ArcSegment#startAngle
-     * @property {Number} - The angle of one side for the arc segment.
+     * @name Two.Arc#startAngle
+     * @property {Number} - The starting angle of the arc in radians.
      */
     if (typeof startAngle === 'number') {
       this.startAngle = startAngle;
     }
 
     /**
-     * @name Two.ArcSegment#endAngle
-     * @property {Number} - The angle of the other side for the arc segment.
+     * @name Two.Arc#endAngle
+     * @property {Number} - The ending angle of the arc in radians.
      */
     if (typeof endAngle === 'number') {
       this.endAngle = endAngle;
@@ -155,10 +155,10 @@ export class Arc extends Path {
    * @name Two.Arc#clone
    * @function
    * @param {Two.Group} [parent] - The parent group or scene to add the clone to.
-   * @returns {Two.ArcSegment}
-   * @description Create a new instance of {@link Two.ArcSegment} with the same properties of the current path.
+   * @returns {Two.Arc}
+   * @description Create a new instance of {@link Two.Arc} with the same properties as the current arc.
    */
-  clone() {
+  clone(parent) {
     const { width, height, startAngle, endAngle } = this;
     const resolution = this.vertices.length;
 

--- a/extras/jsm/zui.d.ts
+++ b/extras/jsm/zui.d.ts
@@ -2,7 +2,7 @@ declare module 'two.js/extras/jsm/zui' {
   /**
    * @name Two.ZUI
    * @class
-   * @param {Group} group - The scene or group to
+   * @param {Group} group - The scene or group to enable panning and zooming on.
    * @param {HTMLElement} [domElement=document.body] - The HTML Element to attach event listeners to.
    */
   export class ZUI {

--- a/extras/jsm/zui.js
+++ b/extras/jsm/zui.js
@@ -29,7 +29,7 @@ class Surface {
 /**
  * @name Two.ZUI
  * @class
- * @param {Two.Group} group - The scene or group to
+ * @param {Two.Group} group - The scene or group to enable panning and zooming on.
  * @param {HTMLElement} [domElement=document.body] - The HTML Element to attach event listeners to.
  * @description {@link Two.ZUI} is an extra class to turn your Two.js scene into a Google Maps or Adobe Illustrator style interface. See {@link https://codepen.io/jonobr1/pen/PobMKwb} for example usage.
  */

--- a/src/group.d.ts
+++ b/src/group.d.ts
@@ -189,7 +189,7 @@ declare module 'two.js/src/group' {
     /**
      * @name Two.Group#ending
      * @property {Number} - Number between zero and one to state the ending of where the path is rendered.
-     * @description {@link Two.Group#ending} is a percentage value that represents at what percentage into all child shapes should the renderer start drawing.
+     * @description {@link Two.Group#ending} is a percentage value that represents at what percentage into all child shapes the renderer should stop drawing.
      * @nota-bene This is great for animating in and out stroked paths in conjunction with {@link Two.Group#beginning}.
      */
     ending: number;

--- a/src/group.js
+++ b/src/group.js
@@ -197,7 +197,7 @@ export class Group extends Shape {
   /**
    * @name Two.Group#ending
    * @property {Number} - Number between zero and one to state the ending of where the path is rendered.
-   * @description {@link Two.Group#ending} is a percentage value that represents at what percentage into all child shapes should the renderer start drawing.
+   * @description {@link Two.Group#ending} is a percentage value that represents at what percentage into all child shapes the renderer should stop drawing.
    * @nota-bene This is great for animating in and out stroked paths in conjunction with {@link Two.Group#beginning}.
    */
   _ending = 1.0;

--- a/src/path.d.ts
+++ b/src/path.d.ts
@@ -259,7 +259,7 @@ declare module 'two.js/src/path' {
     /**
      * @name Two.Path#ending
      * @property {Number} - Number between zero and one to state the ending of where the path is rendered.
-     * @description {@link Two.Path#ending} is a percentage value that represents at what percentage into the path should the renderer start drawing.
+     * @description {@link Two.Path#ending} is a percentage value that represents at what percentage into the path the renderer should stop drawing.
      * @nota-bene This is great for animating in and out stroked paths in conjunction with {@link Two.Path#beginning}.
      */
     ending: number;
@@ -332,7 +332,7 @@ declare module 'two.js/src/path' {
      * @name Two.Path#dashes
      * @type {number[] & { offset?: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
-     * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
+     * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the path.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */
     dashes: number[] & {

--- a/src/path.js
+++ b/src/path.js
@@ -322,7 +322,7 @@ export class Path extends Shape {
     /**
      * @name Two.Path#ending
      * @property {Number} - Number between zero and one to state the ending of where the path is rendered.
-     * @description {@link Two.Path#ending} is a percentage value that represents at what percentage into the path should the renderer start drawing.
+     * @description {@link Two.Path#ending} is a percentage value that represents at what percentage into the path the renderer should stop drawing.
      * @nota-bene This is great for animating in and out stroked paths in conjunction with {@link Two.Path#beginning}.
      */
     this.ending = 1;
@@ -408,7 +408,7 @@ export class Path extends Shape {
     /**
      * @name Two.Path#dashes
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
-     * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
+     * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the path.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */
     this.dashes = [];

--- a/src/shapes/points.d.ts
+++ b/src/shapes/points.d.ts
@@ -78,7 +78,7 @@ declare module 'two.js/src/shapes/points' {
     /**
      * @name Two.Points#ending
      * @property {Number} - Number between zero and one to state the ending of where the path is rendered.
-     * @description {@link Two.Points#ending} is a percentage value that represents at what percentage into the path should the renderer start drawing.
+     * @description {@link Two.Points#ending} is a percentage value that represents at what percentage into the points the renderer should stop drawing.
      */
     ending: number;
     /**
@@ -128,7 +128,7 @@ declare module 'two.js/src/shapes/points' {
      * @name Two.Points#dashes
      * @type {number[] & { offset?: number }}
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
-     * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
+     * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the points.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */
     dashes: number[] & {

--- a/src/shapes/points.js
+++ b/src/shapes/points.js
@@ -97,7 +97,7 @@ export class Points extends Shape {
     /**
      * @name Two.Points#ending
      * @property {Number} - Number between zero and one to state the ending of where the path is rendered.
-     * @description {@link Two.Points#ending} is a percentage value that represents at what percentage into the path should the renderer start drawing.
+     * @description {@link Two.Points#ending} is a percentage value that represents at what percentage into the points the renderer should stop drawing.
      */
     this.ending = 1;
 
@@ -155,7 +155,7 @@ export class Points extends Shape {
     /**
      * @name Two.Points#dashes
      * @property {Number[]} - Array of numbers. Odd indices represent dash length. Even indices represent dash space.
-     * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
+     * @description A list of numbers that represent the repeated dash length and dash space applied to the stroke of the points.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray} for more information on the SVG stroke-dasharray attribute.
      */
     this.dashes = [];

--- a/src/text.d.ts
+++ b/src/text.d.ts
@@ -231,7 +231,7 @@ declare module 'two.js/src/text' {
     alignment: AlignmentProperties;
     /**
      * @name Two.Text#baseline
-     * @property {String} - The vertical aligment of the text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'top'`, `'middle'`, `'bottom'`, and `'baseline'`. Defaults to `'baseline'`.
+     * @property {String} - The vertical alignment of the text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'top'`, `'middle'`, `'bottom'`, and `'baseline'`. Defaults to `'middle'`.
      */
     baseline: BaselineProperties;
     /**

--- a/src/text.js
+++ b/src/text.js
@@ -190,7 +190,7 @@ export class Text extends Shape {
 
   /**
    * @name Two.Text#baseline
-   * @property {String} - The vertical aligment of the text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'top'`, `'middle'`, `'bottom'`, and `'baseline'`. Defaults to `'baseline'`.
+   * @property {String} - The vertical alignment of the text in relation to {@link Two.Text#translation}'s coordinates. Possible values include `'top'`, `'middle'`, `'bottom'`, and `'baseline'`. Defaults to `'middle'`.
    * @nota-bene In headless environments where the canvas is based on {@link https://github.com/Automattic/node-canvas}, `baseline` seems to be the only valid property.
    */
   _baseline = 'middle';

--- a/src/two.d.ts
+++ b/src/two.d.ts
@@ -311,7 +311,7 @@ declare module 'two.js' {
      * @param {Number} y
      * @param {Number} width
      * @param {Number} height
-     * @param {Number} radius
+     * @param {(Number|Vector)} radius
      * @returns {RoundedRectangle}
      * @description Creates a Two.js rounded rectangle and adds it to the scene.
      */
@@ -361,8 +361,8 @@ declare module 'two.js' {
      * @function
      * @param {Number} x
      * @param {Number} y
-     * @param {Number} outerRadius
      * @param {Number} innerRadius
+     * @param {Number} outerRadius
      * @param {Number} sides
      * @returns {Star}
      * @description Creates a Two.js star and adds it to the scene.
@@ -370,8 +370,8 @@ declare module 'two.js' {
     makeStar(
       x: any,
       y: any,
-      outerRadius: number,
       innerRadius: number,
+      outerRadius: number,
       sides: number
     ): Star;
     /**
@@ -517,7 +517,7 @@ declare module 'two.js' {
      * @param {Number} radius
      * @param {...Stop} args - Any number of color stops sometimes referred to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
      * @returns {RadialGradient}
-     * @description Creates a Two.js linear-gradient object and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
+     * @description Creates a Two.js radial-gradient object and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
      */
     makeRadialGradient(
       x1: number,

--- a/src/two.js
+++ b/src/two.js
@@ -765,12 +765,12 @@ export default class Two {
    * @param {Number} y
    * @param {Number} width
    * @param {Number} height
-   * @param {Number} sides
+   * @param {(Number|Two.Vector)} radius
    * @returns {Two.RoundedRectangle}
    * @description Creates a Two.js rounded rectangle and adds it to the scene.
    */
-  makeRoundedRectangle(x, y, width, height, sides) {
-    const rect = new RoundedRectangle(x, y, width, height, sides);
+  makeRoundedRectangle(x, y, width, height, radius) {
+    const rect = new RoundedRectangle(x, y, width, height, radius);
     this.scene.add(rect);
 
     return rect;
@@ -816,14 +816,14 @@ export default class Two {
    * @function
    * @param {Number} x
    * @param {Number} y
-   * @param {Number} outerRadius
    * @param {Number} innerRadius
+   * @param {Number} outerRadius
    * @param {Number} sides
    * @returns {Two.Star}
    * @description Creates a Two.js star and adds it to the scene.
    */
-  makeStar(x, y, outerRadius, innerRadius, sides) {
-    const star = new Star(x, y, outerRadius, innerRadius, sides);
+  makeStar(x, y, innerRadius, outerRadius, sides) {
+    const star = new Star(x, y, innerRadius, outerRadius, sides);
     this.scene.add(star);
 
     return star;
@@ -1045,7 +1045,7 @@ export default class Two {
    * @param {Number} radius
    * @param {...Two.Stop} args - Any number of color stops sometimes referred to as ramp stops. If none are supplied then the default black-to-white two stop gradient is applied.
    * @returns {Two.RadialGradient}
-   * @description Creates a Two.js linear-gradient object and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
+   * @description Creates a Two.js radial-gradient object and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
    */
   makeRadialGradient(x1, y1, radius /* stops */) {
     const stops = Array.prototype.slice.call(arguments, 3);

--- a/wiki/docs/extras/arc/README.md
+++ b/wiki/docs/extras/arc/README.md
@@ -185,7 +185,7 @@ The vertical size of the arc.
 
 ## startAngle
 
-<h2 class="longname" aria-hidden="true"><a href="#startAngle"><span class="prefix">Two.ArcSegment.</span><span class="shortname">startAngle</span></a></h2>
+<h2 class="longname" aria-hidden="true"><a href="#startAngle"><span class="prefix">Two.Arc.</span><span class="shortname">startAngle</span></a></h2>
 
 
 
@@ -199,7 +199,7 @@ The vertical size of the arc.
 <div class="properties">
 
 
-The angle of one side for the arc segment.
+The starting angle of the arc in radians.
 
 
 </div>
@@ -232,7 +232,7 @@ The angle of one side for the arc segment.
 
 ## endAngle
 
-<h2 class="longname" aria-hidden="true"><a href="#endAngle"><span class="prefix">Two.ArcSegment.</span><span class="shortname">endAngle</span></a></h2>
+<h2 class="longname" aria-hidden="true"><a href="#endAngle"><span class="prefix">Two.Arc.</span><span class="shortname">endAngle</span></a></h2>
 
 
 
@@ -246,7 +246,7 @@ The angle of one side for the arc segment.
 <div class="properties">
 
 
-The angle of the other side for the arc segment.
+The ending angle of the arc in radians.
 
 
 </div>
@@ -286,7 +286,7 @@ The angle of the other side for the arc segment.
 
 <div class="returns">
 
-__Returns__: Two.ArcSegment
+__Returns__: Two.Arc
 
 
 
@@ -312,7 +312,7 @@ __Returns__: Two.ArcSegment
 
 <div class="description">
 
-Create a new instance of [Two.ArcSegment](/docs/shapes/arc-segment/) with the same properties of the current path.
+Create a new instance of [Two.Arc](/docs/extras/arc/) with the same properties as the current arc.
 
 </div>
 

--- a/wiki/docs/extras/zui/README.md
+++ b/wiki/docs/extras/zui/README.md
@@ -24,7 +24,7 @@ lang: en-US
 
 | Argument | Description |
 | ---- | ----------- |
-|  group  | The scene or group to |
+|  group  | The scene or group to enable panning and zooming on. |
 |  domElement  | The HTML Element to attach event listeners to. |
 
 

--- a/wiki/docs/group/README.md
+++ b/wiki/docs/group/README.md
@@ -890,7 +890,7 @@ Number between zero and one to state the ending of where the path is rendered.
 
 <div class="description">
 
-[Two.Group.ending](/docs/group/#ending) is a percentage value that represents at what percentage into all child shapes should the renderer start drawing.
+[Two.Group.ending](/docs/group/#ending) is a percentage value that represents at what percentage into all child shapes the renderer should stop drawing.
 
 </div>
 

--- a/wiki/docs/path/README.md
+++ b/wiki/docs/path/README.md
@@ -341,7 +341,7 @@ Number between zero and one to state the ending of where the path is rendered.
 
 <div class="description">
 
-[Two.Path.ending](/docs/path/#ending) is a percentage value that represents at what percentage into the path should the renderer start drawing.
+[Two.Path.ending](/docs/path/#ending) is a percentage value that represents at what percentage into the path the renderer should stop drawing.
 
 </div>
 
@@ -997,7 +997,7 @@ Array of numbers. Odd indices represent dash length. Even indices represent dash
 
 <div class="description">
 
-A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
+A list of numbers that represent the repeated dash length and dash space applied to the stroke of the path.
 
 </div>
 

--- a/wiki/docs/shapes/points/README.md
+++ b/wiki/docs/shapes/points/README.md
@@ -340,7 +340,7 @@ Number between zero and one to state the ending of where the path is rendered.
 
 <div class="description">
 
-[Two.Points.ending](/docs/shapes/points/#ending) is a percentage value that represents at what percentage into the path should the renderer start drawing.
+[Two.Points.ending](/docs/shapes/points/#ending) is a percentage value that represents at what percentage into the points the renderer should stop drawing.
 
 </div>
 
@@ -780,7 +780,7 @@ Array of numbers. Odd indices represent dash length. Even indices represent dash
 
 <div class="description">
 
-A list of numbers that represent the repeated dash length and dash space applied to the stroke of the text.
+A list of numbers that represent the repeated dash length and dash space applied to the stroke of the points.
 
 </div>
 

--- a/wiki/docs/text/README.md
+++ b/wiki/docs/text/README.md
@@ -510,7 +510,7 @@ Alignment of text in relation to [Two.Text.translation](/docs/text/#translation)
 <div class="properties">
 
 
-The vertical aligment of the text in relation to [Two.Text.translation](/docs/text/#translation)'s coordinates. Possible values include `'top'`, `'middle'`, `'bottom'`, and `'baseline'`. Defaults to `'baseline'`.
+The vertical alignment of the text in relation to [Two.Text.translation](/docs/text/#translation)'s coordinates. Possible values include `'top'`, `'middle'`, `'bottom'`, and `'baseline'`. Defaults to `'middle'`.
 
 
 </div>

--- a/wiki/docs/two/README.md
+++ b/wiki/docs/two/README.md
@@ -1758,7 +1758,7 @@ __Returns__: Two.RoundedRectangle
 |  y  |  |
 |  width  |  |
 |  height  |  |
-|  sides  |  |
+|  radius  |  |
 </div>
 
 
@@ -1947,8 +1947,8 @@ __Returns__: Two.Star
 | ---- | ----------- |
 |  x  |  |
 |  y  |  |
-|  outerRadius  |  |
 |  innerRadius  |  |
+|  outerRadius  |  |
 |  sides  |  |
 </div>
 
@@ -2475,7 +2475,7 @@ __Returns__: Two.RadialGradient
 
 <div class="description">
 
-Creates a Two.js linear-gradient object and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
+Creates a Two.js radial-gradient object and adds it to the scene. In the case of an effect it's added to an invisible "definitions" group.
 
 </div>
 


### PR DESCRIPTION
Corrected inconsistent JSDoc, TypeScript, and generated wiki docs across Arc, ZUI, Group, Path, Points, Text, and gradient docs. Also aligned `makeRoundedRectangle` naming (`radius`) and updated `makeStar` to use the documented `(innerRadius, outerRadius)` argument order when constructing `Star`, keeping the public API and implementation consistent.