### PR TITLE
Restore serialized textures as Two.Texture instances

### DIFF
--- a/src/effects/image-sequence.js
+++ b/src/effects/image-sequence.js
@@ -196,7 +196,31 @@ export class ImageSequence extends Rectangle {
    * @nota-bene Works in conjunction with {@link Two.ImageSequence#toObject}
    */
   static fromObject(obj) {
-    const sequence = new ImageSequence().copy(obj);
+    let source = obj;
+
+    // Serialized image sequences store their textures in object notation.
+    // Convert them before copying, because the textures setter binds events
+    // on each item.
+    if (Array.isArray(obj.textures)) {
+      const textures = [];
+      let converted = false;
+
+      for (let i = 0; i < obj.textures.length; i++) {
+        const texture = obj.textures[i];
+        if (texture instanceof Texture) {
+          textures.push(texture);
+        } else {
+          textures.push(Texture.fromObject(texture));
+          converted = true;
+        }
+      }
+
+      if (converted) {
+        source = { ...obj, textures };
+      }
+    }
+
+    const sequence = new ImageSequence().copy(source);
 
     if ('id' in obj) {
       sequence.id = obj.id;

--- a/src/effects/image.js
+++ b/src/effects/image.js
@@ -107,6 +107,11 @@ export class Image extends Rectangle {
   static fromObject(obj) {
     const image = new Image().copy(obj);
 
+    // Serialized images store their texture in object notation
+    if (obj.texture && !(obj.texture instanceof Texture)) {
+      image.texture = Texture.fromObject(obj.texture);
+    }
+
     if ('id' in obj) {
       image.id = obj.id;
     }

--- a/src/effects/sprite.js
+++ b/src/effects/sprite.js
@@ -231,6 +231,11 @@ export class Sprite extends Rectangle {
   static fromObject(obj) {
     const sprite = new Sprite().copy(obj);
 
+    // Serialized sprites store their texture in object notation
+    if (obj.texture && !(obj.texture instanceof Texture)) {
+      sprite.texture = Texture.fromObject(obj.texture);
+    }
+
     if ('id' in obj) {
       sprite.id = obj.id;
     }

--- a/src/effects/texture.js
+++ b/src/effects/texture.js
@@ -199,7 +199,7 @@ export class Texture extends Element {
    * @description Create a new {@link Two.Texture} from an object notation of a {@link Two.Texture}.
    * @nota-bene Works in conjunction with {@link Two.Texture#toObject}
    */
-  fromObject(obj) {
+  static fromObject(obj) {
     const texture = new Texture().copy(obj);
 
     if ('id' in obj) {

--- a/tests/suite/core.js
+++ b/tests/suite/core.js
@@ -1333,6 +1333,106 @@ QUnit.test('Two.Text Object Conversion', function (assert) {
   );
 });
 
+QUnit.test('Two.Texture Object Conversion', function (assert) {
+  assert.expect(14);
+
+  var src = '/tests/images/sequence/00000.png';
+
+  var texture = new Two.Texture(src);
+  texture.id = 'my-texture';
+
+  var restored = Two.Texture.fromObject(texture.toObject());
+  assert.ok(
+    restored instanceof Two.Texture,
+    'Two.Texture.fromObject returns a Two.Texture'
+  );
+  assert.equal(restored.src, texture.src, 'Two.Texture.fromObject preserves src');
+  assert.equal(restored.id, texture.id, 'Two.Texture.fromObject preserves id');
+
+  var path = new Two.Path([new Two.Anchor(0, 0), new Two.Anchor(10, 10)]);
+  path.fill = new Two.Texture(src);
+  path.stroke = new Two.Texture(src);
+
+  var newPath = Two.Path.fromObject(path.toObject());
+  assert.ok(
+    newPath.fill instanceof Two.Texture,
+    'Two.Path.fromObject restores a texture fill as a Two.Texture'
+  );
+  assert.ok(
+    newPath.stroke instanceof Two.Texture,
+    'Two.Path.fromObject restores a texture stroke as a Two.Texture'
+  );
+  assert.equal(
+    newPath.fill.src,
+    path.fill.src,
+    'Two.Path.fromObject preserves the texture fill src'
+  );
+
+  var text = new Two.Text('Hello', 0, 0);
+  text.fill = new Two.Texture(src);
+
+  var newText = Two.Text.fromObject(text.toObject());
+  assert.ok(
+    newText.fill instanceof Two.Texture,
+    'Two.Text.fromObject restores a texture fill as a Two.Texture'
+  );
+
+  var group = new Two.Group();
+  var child = new Two.Path([new Two.Anchor(0, 0), new Two.Anchor(10, 10)]);
+  child.fill = new Two.Texture(src);
+  group.add(child);
+
+  var newGroup = Two.Group.fromObject(group.toObject());
+  assert.ok(
+    newGroup.children[0].fill instanceof Two.Texture,
+    'Two.Group.fromObject restores a nested texture fill as a Two.Texture'
+  );
+
+  var image = new Two.Image(src, 0, 0, 10, 10);
+  var newImage = Two.Image.fromObject(image.toObject());
+  assert.ok(
+    newImage.texture instanceof Two.Texture,
+    'Two.Image.fromObject restores its texture as a Two.Texture'
+  );
+  assert.equal(
+    newImage.texture.src,
+    image.texture.src,
+    'Two.Image.fromObject preserves the texture src'
+  );
+
+  var sprite = new Two.Sprite('/tests/images/spritesheet.jpg', 0, 0, 4, 4);
+  var newSprite = Two.Sprite.fromObject(sprite.toObject());
+  assert.ok(
+    newSprite.texture instanceof Two.Texture,
+    'Two.Sprite.fromObject restores its texture as a Two.Texture'
+  );
+
+  var sequence = new Two.ImageSequence(
+    [
+      '/tests/images/sequence/00000.png',
+      '/tests/images/sequence/00001.png',
+    ],
+    0,
+    0
+  );
+  var newSequence = Two.ImageSequence.fromObject(sequence.toObject());
+  assert.equal(
+    newSequence.textures.length,
+    2,
+    'Two.ImageSequence.fromObject preserves the number of textures'
+  );
+  assert.ok(
+    newSequence.textures[0] instanceof Two.Texture &&
+      newSequence.textures[1] instanceof Two.Texture,
+    'Two.ImageSequence.fromObject restores its textures as Two.Texture instances'
+  );
+  assert.equal(
+    newSequence.textures[1].src,
+    sequence.textures[1].src,
+    'Two.ImageSequence.fromObject preserves the texture src values'
+  );
+});
+
 QUnit.test('Two.Text strokeAttenuation', function (assert) {
   assert.expect(4);
 


### PR DESCRIPTION
Fixes #842

## Changes

- `src/effects/texture.js`: declare `fromObject` as `static`, which `texture.d.ts` already does. Before, `Two.Texture.fromObject()` resolved to the inherited `Element.fromObject()` and returned an `Element`. `getEffectFromObject` calls `Texture.fromObject`, so `Path`, `Text`, and `Group` restored texture fills and strokes as plain `Element` instances.
- `src/effects/image.js` and `src/effects/sprite.js`: `toObject()` stores `texture` in object notation, and `fromObject()` copied that plain object back. `fromObject()` now converts it with `Texture.fromObject()`.
- `src/effects/image-sequence.js`: same fix for `textures`. The conversion runs before `copy()`, because the `textures` setter binds events on each item. With plain objects, `ImageSequence.fromObject()` threw `items[i].bind is not a function`. Items that are already `Texture` instances are kept, and the input object is not mutated.
- `tests/suite/core.js`: new `Two.Texture Object Conversion` test. It covers a direct round trip, texture fill and stroke through `Path`, `Text`, and nested `Group`, and textures through `Image`, `Sprite`, and `ImageSequence`.

## Verification

I ran `npm run build`, then ran `tests/index.html` and `tests/noWebGL.html` in headless Chromium with Playwright, served from a local static server:

| | tests/index.html | tests/noWebGL.html |
|---|---|---|
| Before, with the new test | 792 of 807 assertions passed. The new test failed 11 assertions and died on `ImageSequence` | not run |
| After | 804 of 808 passed | 569 of 571 passed |

On an unchanged checkout, the same 4 assertions also fail on `index.html`, and the same 2 on `noWebGL.html`. They are the image comparisons in `two.makeImage (Mode: fit)` and `(Mode switching)` for Canvas and WebGL. I think headless rendering causes them, not this change.

`npx eslint` on the changed files and `npm run types:check` both pass. I did not commit the `build/` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
