### PR TITLE
Keep Group.center and corner from writing non-finite translations

### DIFF
--- a/src/group.js
+++ b/src/group.js
@@ -24,6 +24,20 @@ import { Sprite } from './effects/sprite.js';
 const min = Math.min,
   max = Math.max;
 
+/**
+ * @private
+ * @param {Object} rect - A bounding rect from {@link Two.Group#getBoundingClientRect}.
+ * @returns {Boolean} Whether the rect has finite bounds. An empty group, or a group whose children are all hidden or effects, has infinite bounds.
+ */
+function hasFiniteBounds(rect) {
+  return (
+    isFinite(rect.left) &&
+    isFinite(rect.top) &&
+    isFinite(rect.right) &&
+    isFinite(rect.bottom)
+  );
+}
+
 const cache = {
   getShapesAtPoint: {
     results: [],
@@ -700,6 +714,12 @@ export class Group extends Shape {
   corner() {
     const rect = this.getBoundingClientRect(true);
 
+    // Without visible, measurable children the bounds are not finite,
+    // so there is nothing to orient to.
+    if (!hasFiniteBounds(rect)) {
+      return this;
+    }
+
     for (let i = 0; i < this.children.length; i++) {
       const child = this.children[i];
       child.translation.x -= rect.left;
@@ -721,6 +741,13 @@ export class Group extends Shape {
    */
   center() {
     const rect = this.getBoundingClientRect(true);
+
+    // Without visible, measurable children the bounds are not finite,
+    // so there is nothing to orient to.
+    if (!hasFiniteBounds(rect)) {
+      return this;
+    }
+
     const cx = rect.left + rect.width / 2 - this.translation.x;
     const cy = rect.top + rect.height / 2 - this.translation.y;
 

--- a/tests/suite/core.js
+++ b/tests/suite/core.js
@@ -1298,6 +1298,97 @@ QUnit.test('Two.Group.getBoundingClientRect(shallow)', function (assert) {
   );
 });
 
+QUnit.test('Two.Group.center and corner without visible bounds', function (assert) {
+  assert.expect(16);
+
+  const isFiniteVector = function (vector) {
+    return isFinite(vector.x) && isFinite(vector.y);
+  };
+
+  for (const method of ['center', 'corner']) {
+    // Empty group with a mask
+    const empty = new Two.Group();
+    empty.mask = new Two.Rectangle(0, 0, 10, 10);
+    empty[method]();
+    assert.ok(
+      isFiniteVector(empty.mask.translation),
+      `Two.Group.${method} keeps the mask translation finite on an empty group.`
+    );
+    assert.deepEqual(
+      [empty.mask.translation.x, empty.mask.translation.y],
+      [0, 0],
+      `Two.Group.${method} does not move the mask of an empty group.`
+    );
+
+    // Group whose children are all hidden
+    const hidden = new Two.Rectangle(10, 20, 5, 5);
+    hidden.visible = false;
+    const hiddenGroup = new Two.Group(hidden);
+    hiddenGroup[method]();
+    assert.ok(
+      isFiniteVector(hidden.translation),
+      `Two.Group.${method} keeps hidden children translations finite.`
+    );
+    assert.deepEqual(
+      [hidden.translation.x, hidden.translation.y],
+      [10, 20],
+      `Two.Group.${method} leaves hidden-only children in place.`
+    );
+
+    // Group that only holds an effect, which bounds ignore
+    const effectGroup = new Two.Group();
+    effectGroup.add(new Two.LinearGradient());
+    effectGroup.mask = new Two.Rectangle(0, 0, 10, 10);
+    effectGroup[method]();
+    assert.ok(
+      isFiniteVector(effectGroup.mask.translation),
+      `Two.Group.${method} keeps the mask translation finite on an effect-only group.`
+    );
+
+    // Mixed visible and hidden children still orient to the visible bounds
+    const visible = new Two.Rectangle(100, 100, 20, 20);
+    const invisible = new Two.Rectangle(-500, -500, 20, 20);
+    invisible.visible = false;
+    const mixed = new Two.Group(visible, invisible);
+    mixed[method]();
+    assert.ok(
+      isFiniteVector(visible.translation) && isFiniteVector(invisible.translation),
+      `Two.Group.${method} keeps translations finite for mixed children.`
+    );
+    const rect = mixed.getBoundingClientRect(true);
+    if (method === 'center') {
+      assert.ok(
+        Math.abs(rect.left + rect.width / 2) < 1e-9 &&
+          Math.abs(rect.top + rect.height / 2) < 1e-9,
+        'Two.Group.center centers the visible children of a mixed group.'
+      );
+    } else {
+      assert.ok(
+        Math.abs(rect.left) < 1e-9 && Math.abs(rect.top) < 1e-9,
+        'Two.Group.corner corners the visible children of a mixed group.'
+      );
+    }
+  }
+
+  // Hidden children must not change the result for visible ones
+  const reference = new Two.Group(new Two.Rectangle(100, 100, 20, 20));
+  reference.center();
+  const withHidden = new Two.Rectangle(-500, -500, 20, 20);
+  withHidden.visible = false;
+  const compared = new Two.Group(new Two.Rectangle(100, 100, 20, 20), withHidden);
+  compared.center();
+  assert.equal(
+    compared.children[0].translation.x,
+    reference.children[0].translation.x,
+    'Two.Group.center ignores hidden children when computing x.'
+  );
+  assert.equal(
+    compared.children[0].translation.y,
+    reference.children[0].translation.y,
+    'Two.Group.center ignores hidden children when computing y.'
+  );
+});
+
 QUnit.test('Two.Text Object Conversion', function (assert) {
   assert.expect(9);
 


### PR DESCRIPTION
Fixes #849

## Changes

- `src/group.js`: `center()` and `corner()` return early when `getBoundingClientRect(true)` has non-finite bounds. That happens for an empty group, a group whose children are all hidden, and a group that only holds effects. Before, they subtracted `Infinity` from every child translation and the mask translation. `center()` produced `NaN`, and `corner()` produced `-Infinity`. A small module-scope helper, `hasFiniteBounds`, does the check, so no allocations are added.
- `tests/suite/core.js`: new `Two.Group.center and corner without visible bounds` test, run for both methods:
  - empty group with a mask: the mask stays at `(0, 0)`
  - hidden-only group: the children keep their translation
  - effect-only group (a `LinearGradient` child) with a mask: the mask stays finite
  - mixed visible and hidden children: the visible bounds are still centered or cornered
  - hidden children do not change the `center()` result for the visible ones

## Verification

I ran `npm run build`, then ran the pages in headless Chromium with Playwright, served from a local static server:

| | tests/index.html | tests/noWebGL.html |
|---|---|---|
| Without the `src/group.js` change | 792 of 807 assertions passed. The new test failed 11 assertions, and it died when `corner()` threw on the effect-only group | not run |
| With the change | 806 of 810 passed | 571 of 573 passed |

On an unchanged checkout, the same 4 assertions also fail on `index.html`, and the same 2 on `noWebGL.html`. They are the `two.makeImage (Mode: fit)` and `(Mode switching)` image comparisons.

`npx eslint src/group.js tests/suite/core.js` and `npm run types:check` pass. I did not commit the `build/` output.

## Note

Without this change, `corner()` threw on the effect-only group, because it does not check `child.isShape` the way `center()` does. The early return covers that case, but a group with a visible shape and a gradient child would still hit the unguarded loop in `corner()`. I left that out of this PR to keep it focused on #849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
