### PR TITLE
Fix Events.listen throwing and removeEventListener dropping listen scope

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -72,9 +72,11 @@ export class Events {
         let events = [];
         if (handler) {
           for (let j = 0, k = list.length; j < k; j++) {
-            let e = list[j];
-            e = e.handler ? e.handler : e;
-            if (handler !== e) {
+            const e = list[j];
+            // Compare against the original handler of a `listen` wrapper,
+            // but keep the wrapper itself so its scope is preserved.
+            const callback = e.handler ? e.handler : e;
+            if (handler !== callback) {
               events.push(e);
             }
           }
@@ -140,9 +142,10 @@ export class Events {
 
     if (obj) {
 
-      // Add references about the object that assigned this listener
+      // Add references about the object that assigned this listener.
+      // A function's `name` is read-only, so store the event name as `event`.
       e.obj = obj;
-      e.name = name;
+      e.event = name;
       e.handler = handler;
 
       obj.on(name, e);

--- a/tests/suite/core.js
+++ b/tests/suite/core.js
@@ -26,6 +26,81 @@ QUnit.test('Two.Events', function (assert) {
   item.trigger('change');
 });
 
+QUnit.test('Two.Events listen and ignore', function (assert) {
+  assert.expect(10);
+
+  var source = new Two.Events();
+  var listener = new Two.Events();
+  var calls = [];
+  var handler = function (value) {
+    calls.push({ scope: this, value: value });
+  };
+  var other = function () {};
+
+  var result;
+  try {
+    result = listener.listen(source, 'change', handler);
+    assert.ok(true, 'Two.Events.listen does not throw.');
+  } catch (error) {
+    assert.ok(false, 'Two.Events.listen does not throw: ' + error.message);
+  }
+  assert.equal(result, listener, 'Two.Events.listen returns the listener.');
+
+  source.trigger('change', 1);
+  assert.equal(calls.length, 1, 'Two.Events.listen subscribes the handler.');
+  assert.equal(
+    calls[0] && calls[0].scope,
+    listener,
+    'Two.Events.listen calls the handler with the listener as scope.'
+  );
+
+  // Removing a different handler must keep the listen wrapper intact.
+  source.bind('change', other);
+  source.unbind('change', other);
+  source.trigger('change', 2);
+  assert.equal(
+    calls[1] && calls[1].scope,
+    listener,
+    'Removing a different handler keeps the listen scope.'
+  );
+  assert.equal(
+    calls[1] && calls[1].value,
+    2,
+    'Removing a different handler keeps passing arguments.'
+  );
+
+  listener.ignore(source, 'change', handler);
+  source.trigger('change', 3);
+  assert.equal(calls.length, 2, 'Two.Events.ignore removes the listen wrapper.');
+
+  var collection = new Two.Collection();
+  var collectionCalls = [];
+  var collectionHandler = function () {
+    collectionCalls.push(this);
+  };
+
+  collection.listen(source, 'update', collectionHandler);
+  source.trigger('update');
+  assert.equal(
+    collectionCalls.length,
+    1,
+    'Two.Collection.listen subscribes the handler.'
+  );
+  assert.equal(
+    collectionCalls[0],
+    collection,
+    'Two.Collection.listen calls the handler with the collection as scope.'
+  );
+
+  collection.ignore(source, 'update', collectionHandler);
+  source.trigger('update');
+  assert.equal(
+    collectionCalls.length,
+    1,
+    'Two.Collection.ignore removes the listen wrapper.'
+  );
+});
+
 QUnit.test('Two.Vector', function (assert) {
   assert.expect(48);
 


### PR DESCRIPTION
Fixes #844

## Changes

- `src/events.js`, `listen()`: stop writing to the wrapper's read-only `name`. Class bodies are strict mode, so `e.name = name` threw before the listener was registered. The event name is now stored as `e.event`. `obj` and `handler` are stored as before, and nothing in `src/` read `name`.
- `src/events.js`, `removeEventListener()`: it used the original handler of a `listen` wrapper for the comparison, but also pushed that original handler back into the list instead of the wrapper. Any `unbind` or `ignore` call that named a specific handler replaced the other `listen` wrappers on that event with their raw handlers. Those handlers then ran with the emitter as `this` instead of the listener. The loop now keeps the original entry.
- `tests/suite/core.js`: new `Two.Events listen and ignore` test:
  - `listen` does not throw, returns the listener, and calls the handler with the listener as scope.
  - After a different handler is bound and unbound, the `listen` wrapper keeps its scope and arguments.
  - `ignore` removes the wrapper.
  - The same subscribe, scope, and ignore checks through the `Two.Collection` proxy.

## Verification

I ran `npm run build`, then ran the pages in headless Chromium with Playwright, served from a local static server:

| | tests/index.html | new test |
|---|---|---|
| Neither fix | 790 of 803 assertions passed | `listen` throws, the test died after 8 of 10 assertions |
| Only the `listen` fix | 799 of 804 passed | 1 failure: the scope changed after removing a different handler |
| Both fixes | 800 of 804 passed | 10 of 10 passed |

`tests/noWebGL.html` with both fixes: 565 of 567 assertions passed.

On an unchanged checkout, the same 4 assertions also fail on `index.html`, and the same 2 on `noWebGL.html`. They are the `two.makeImage (Mode: fit)` and `(Mode switching)` image comparisons.

`npx eslint src/events.js tests/suite/core.js` and `npm run types:check` pass. I did not commit the `build/` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
